### PR TITLE
카카오 계정으로 로그인 & 채팅 창 추가 기능 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,19 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <!-- 리다이렉트 URI: "kakao${NATIVE_APP_KEY}://oauth" -->
+                <data android:host="oauth"
+                    android:scheme="kakao01d7add26392012e075b18f95d9466bf" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/core/addresspicker/src/main/kotlin/com/ssavice/mappicker/datasource/ConvertCoordinateDatasource.kt
+++ b/core/addresspicker/src/main/kotlin/com/ssavice/mappicker/datasource/ConvertCoordinateDatasource.kt
@@ -1,8 +1,8 @@
 package com.ssavice.mappicker.datasource
 
 import com.ssavice.core.mappicker.BuildConfig
-import com.ssavice.network.retrofit.service.KakaoRestService
 import com.ssavice.mappicker.model.CoordinateConvertResult
+import com.ssavice.network.retrofit.service.KakaoRestService
 import javax.inject.Inject
 
 class ConvertCoordinateDatasource

--- a/core/addresspicker/src/main/kotlin/com/ssavice/mappicker/datasource/ConvertCoordinateDatasource.kt
+++ b/core/addresspicker/src/main/kotlin/com/ssavice/mappicker/datasource/ConvertCoordinateDatasource.kt
@@ -1,7 +1,7 @@
 package com.ssavice.mappicker.datasource
 
 import com.ssavice.core.mappicker.BuildConfig
-import com.ssavice.data.service.KakaoRestService
+import com.ssavice.network.retrofit.service.KakaoRestService
 import com.ssavice.mappicker.model.CoordinateConvertResult
 import javax.inject.Inject
 

--- a/core/chat/src/main/kotlin/com/ssavice/chat/model/network/GetRoomInfoDTO.kt
+++ b/core/chat/src/main/kotlin/com/ssavice/chat/model/network/GetRoomInfoDTO.kt
@@ -1,7 +1,6 @@
 package com.ssavice.chat.model.network
 
 import com.ssavice.model.chat.ChattingRoomInfo
-import com.ssavice.model.chat.ChattingRoomParticipant
 import com.ssavice.model.enums.RoomType
 import com.ssavice.model.enums.getValue
 import kotlinx.serialization.SerialName
@@ -22,19 +21,6 @@ data class GetRoomInfoDTO(
             name = name,
             roomType = RoomType.getValue(roomType),
             serviceId = serviceId ?: 0,
-        )
-}
-
-@Serializable
-data class RoomParticipantDTO(
-    val name: String,
-    val userId: Long,
-    val thumbnail: String?,
-) {
-    fun toModel(): ChattingRoomParticipant =
-        ChattingRoomParticipant(
-            name = name,
-            userId = userId,
-            thumbnail = thumbnail ?: "",
+            participantIds = members.values.toList(),
         )
 }

--- a/core/chat/src/main/kotlin/com/ssavice/chat/repository/ChatRepository.kt
+++ b/core/chat/src/main/kotlin/com/ssavice/chat/repository/ChatRepository.kt
@@ -6,6 +6,8 @@ import com.ssavice.chat.model.network.GetRoomInfoDTO
 import com.ssavice.model.chat.Chat
 import com.ssavice.model.chat.ChattingRoomInfo
 import com.ssavice.model.chat.ChattingRoomMetadata
+import com.ssavice.model.chat.ChattingServiceSummary
+import com.ssavice.model.chat.ChattingUserInfo
 import com.ssavice.model.enums.RoomType
 import com.ssavice.room.dto.ChatEntity
 import kotlinx.coroutines.flow.Flow
@@ -45,4 +47,18 @@ interface ChatRepository {
         serviceId: Long,
         userId: Long,
     ): Flow<Result<String>>
+
+    fun getUserInfoMap(): Flow<Map<Long, ChattingUserInfo>>
+
+    suspend fun getMyId(): Result<Long>
+
+    fun getChatServiceSummaryMap(): Flow<Map<Long, ChattingServiceSummary>>
+
+    suspend fun updateUserInfoIfNeed(
+        userIds: List<Long>
+    ): Result<Unit>
+
+    suspend fun updateServiceSummaryIfNeed(
+        serviceId: Long
+    ): Result<Unit>
 }

--- a/core/chat/src/main/kotlin/com/ssavice/chat/repository/ChatRepository.kt
+++ b/core/chat/src/main/kotlin/com/ssavice/chat/repository/ChatRepository.kt
@@ -54,11 +54,7 @@ interface ChatRepository {
 
     fun getChatServiceSummaryMap(): Flow<Map<Long, ChattingServiceSummary>>
 
-    suspend fun updateUserInfoIfNeed(
-        userIds: List<Long>
-    ): Result<Unit>
+    suspend fun updateUserInfoIfNeed(userIds: List<Long>): Result<Unit>
 
-    suspend fun updateServiceSummaryIfNeed(
-        serviceId: Long
-    ): Result<Unit>
+    suspend fun updateServiceSummaryIfNeed(serviceId: Long): Result<Unit>
 }

--- a/core/chat/src/main/kotlin/com/ssavice/chat/repository/ChatRepositoryImpl.kt
+++ b/core/chat/src/main/kotlin/com/ssavice/chat/repository/ChatRepositoryImpl.kt
@@ -9,11 +9,16 @@ import com.ssavice.chat.ChatRemoteMediator
 import com.ssavice.chat.WebSocketEventHandler
 import com.ssavice.chat.model.enum.ChatCursorDirection
 import com.ssavice.chat.service.ChatRetrofitService
+import com.ssavice.datastore.repository.ChattingMetadataRepository
 import com.ssavice.model.chat.Chat
 import com.ssavice.model.chat.ChattingRoomInfo
 import com.ssavice.model.chat.ChattingRoomMetadata
+import com.ssavice.model.chat.ChattingServiceSummary
+import com.ssavice.model.chat.ChattingUserInfo
 import com.ssavice.model.enums.RoomType
 import com.ssavice.model.enums.getValue
+import com.ssavice.network.retrofit.service.ServiceRetrofitService
+import com.ssavice.network.retrofit.service.UserInfoRetrofitService
 import com.ssavice.network.websocket.ChatWebSocketManager
 import com.ssavice.network.websocket.model.WebSocketRxEntity
 import com.ssavice.network.websocket.model.WebSocketTxEntity
@@ -36,6 +41,7 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import javax.inject.Inject
+import kotlin.collections.filter
 
 class ChatRepositoryImpl
     @Inject
@@ -46,6 +52,9 @@ class ChatRepositoryImpl
         private val chatDatabase: ChatDatabase,
         private val webSocketManager: ChatWebSocketManager,
         private val eventHandler: WebSocketEventHandler,
+        private val userRetrofitService: UserInfoRetrofitService,
+        private val serviceRetrofitSummary: ServiceRetrofitService,
+        private val metadataRepository: ChattingMetadataRepository
     ) : ChatRepository {
         init {
             eventHandler.startObserving()
@@ -231,4 +240,43 @@ class ChatRepositoryImpl
                         }
                     }
                 }
+
+    override fun getUserInfoMap(): Flow<Map<Long, ChattingUserInfo>> {
+        return metadataRepository.getUserInfoFlow()
     }
+
+    override suspend fun getMyId(): Result<Long> {
+        return userRetrofitService.getMyUserId().map { it.id }
+    }
+
+    override fun getChatServiceSummaryMap(): Flow<Map<Long, ChattingServiceSummary>> {
+        return metadataRepository.getServiceSummaryFlow()
+    }
+
+    private suspend fun getIfUserInfoNeedUpdate(userId: Long): Boolean {
+        val data = metadataRepository.getUserInfo(userId)
+        data.onSuccess {
+            return it.needRefresh()
+        }
+        return true
+    }
+
+    private suspend fun getUserInfoFromRemoteAndUpdate(userId: List<Long>): Result<Unit> {
+        val result = userRetrofitService.getUserInfoSummary(userId)
+        return result.map { it.toModel() }.onSuccess { data ->
+            metadataRepository.setUserInfos(data)
+        }.map { Unit }
+    }
+
+    override suspend fun updateUserInfoIfNeed(userIds: List<Long>): Result<Unit> {
+        val updateList = userIds.filter { getIfUserInfoNeedUpdate(it) }
+        return getUserInfoFromRemoteAndUpdate(updateList)
+    }
+
+    override suspend fun updateServiceSummaryIfNeed(serviceId: Long): Result<Unit> {
+        val result = serviceRetrofitSummary.getServiceSummary(serviceId)
+        return result.map { it.toModel(serviceId) }.onSuccess { data ->
+            metadataRepository.setServiceSummary(data)
+        }.map { Unit }
+    }
+}

--- a/core/chat/src/main/kotlin/com/ssavice/chat/repository/ChatRepositoryImpl.kt
+++ b/core/chat/src/main/kotlin/com/ssavice/chat/repository/ChatRepositoryImpl.kt
@@ -54,7 +54,7 @@ class ChatRepositoryImpl
         private val eventHandler: WebSocketEventHandler,
         private val userRetrofitService: UserInfoRetrofitService,
         private val serviceRetrofitSummary: ServiceRetrofitService,
-        private val metadataRepository: ChattingMetadataRepository
+        private val metadataRepository: ChattingMetadataRepository,
     ) : ChatRepository {
         init {
             eventHandler.startObserving()
@@ -241,42 +241,40 @@ class ChatRepositoryImpl
                     }
                 }
 
-    override fun getUserInfoMap(): Flow<Map<Long, ChattingUserInfo>> {
-        return metadataRepository.getUserInfoFlow()
-    }
+        override fun getUserInfoMap(): Flow<Map<Long, ChattingUserInfo>> = metadataRepository.getUserInfoFlow()
 
-    override suspend fun getMyId(): Result<Long> {
-        return userRetrofitService.getMyUserId().map { it.id }
-    }
+        override suspend fun getMyId(): Result<Long> = userRetrofitService.getMyUserId().map { it.id }
 
-    override fun getChatServiceSummaryMap(): Flow<Map<Long, ChattingServiceSummary>> {
-        return metadataRepository.getServiceSummaryFlow()
-    }
+        override fun getChatServiceSummaryMap(): Flow<Map<Long, ChattingServiceSummary>> = metadataRepository.getServiceSummaryFlow()
 
-    private suspend fun getIfUserInfoNeedUpdate(userId: Long): Boolean {
-        val data = metadataRepository.getUserInfo(userId)
-        data.onSuccess {
-            return it.needRefresh()
+        private suspend fun getIfUserInfoNeedUpdate(userId: Long): Boolean {
+            val data = metadataRepository.getUserInfo(userId)
+            data.onSuccess {
+                return it.needRefresh()
+            }
+            return true
         }
-        return true
-    }
 
-    private suspend fun getUserInfoFromRemoteAndUpdate(userId: List<Long>): Result<Unit> {
-        val result = userRetrofitService.getUserInfoSummary(userId)
-        return result.map { it.toModel() }.onSuccess { data ->
-            metadataRepository.setUserInfos(data)
-        }.map { Unit }
-    }
+        private suspend fun getUserInfoFromRemoteAndUpdate(userId: List<Long>): Result<Unit> {
+            val result = userRetrofitService.getUserInfoSummary(userId)
+            return result
+                .map { it.toModel() }
+                .onSuccess { data ->
+                    metadataRepository.setUserInfos(data)
+                }.map { Unit }
+        }
 
-    override suspend fun updateUserInfoIfNeed(userIds: List<Long>): Result<Unit> {
-        val updateList = userIds.filter { getIfUserInfoNeedUpdate(it) }
-        return getUserInfoFromRemoteAndUpdate(updateList)
-    }
+        override suspend fun updateUserInfoIfNeed(userIds: List<Long>): Result<Unit> {
+            val updateList = userIds.filter { getIfUserInfoNeedUpdate(it) }
+            return getUserInfoFromRemoteAndUpdate(updateList)
+        }
 
-    override suspend fun updateServiceSummaryIfNeed(serviceId: Long): Result<Unit> {
-        val result = serviceRetrofitSummary.getServiceSummary(serviceId)
-        return result.map { it.toModel(serviceId) }.onSuccess { data ->
-            metadataRepository.setServiceSummary(data)
-        }.map { Unit }
+        override suspend fun updateServiceSummaryIfNeed(serviceId: Long): Result<Unit> {
+            val result = serviceRetrofitSummary.getServiceSummary(serviceId)
+            return result
+                .map { it.toModel(serviceId) }
+                .onSuccess { data ->
+                    metadataRepository.setServiceSummary(data)
+                }.map { Unit }
+        }
     }
-}

--- a/core/chat/src/main/kotlin/com/ssavice/chat/service/FakeChatRetrofitService.kt
+++ b/core/chat/src/main/kotlin/com/ssavice/chat/service/FakeChatRetrofitService.kt
@@ -7,10 +7,6 @@ import com.ssavice.chat.model.network.GetRoomInfoDTO
 import com.ssavice.chat.model.network.GetRoomListDTO
 import com.ssavice.chat.model.network.MessageDTO
 import com.ssavice.chat.model.network.RoomDTO
-import com.ssavice.chat.model.network.RoomParticipantDTO
-import com.ssavice.room.dto.ChatEntity
-import retrofit2.Response
-import java.time.LocalDateTime
 
 class FakeChatRetrofitService : ChatRetrofitService {
     val lastId = 500L

--- a/core/data/src/main/java/com/ssavice/data/di/CompanyRetrofitModule.kt
+++ b/core/data/src/main/java/com/ssavice/data/di/CompanyRetrofitModule.kt
@@ -1,9 +1,8 @@
 package com.ssavice.data.di
 
 import com.ssavice.data.repository.SellerInfoRepository
-import com.ssavice.data.repositoryimpl.DemoSellerInfoRepository
 import com.ssavice.data.repositoryimpl.RemoteSellerInfoRepository
-import com.ssavice.data.service.CompanyRetrofitService
+import com.ssavice.network.retrofit.service.CompanyRetrofitService
 import com.ssavice.network.di.RetrofitModule
 import dagger.Binds
 import dagger.Module

--- a/core/data/src/main/java/com/ssavice/data/di/CompanyRetrofitModule.kt
+++ b/core/data/src/main/java/com/ssavice/data/di/CompanyRetrofitModule.kt
@@ -2,8 +2,8 @@ package com.ssavice.data.di
 
 import com.ssavice.data.repository.SellerInfoRepository
 import com.ssavice.data.repositoryimpl.RemoteSellerInfoRepository
-import com.ssavice.network.retrofit.service.CompanyRetrofitService
 import com.ssavice.network.di.RetrofitModule
+import com.ssavice.network.retrofit.service.CompanyRetrofitService
 import dagger.Binds
 import dagger.Module
 import dagger.Provides

--- a/core/data/src/main/java/com/ssavice/data/di/ImageRetrofitModule.kt
+++ b/core/data/src/main/java/com/ssavice/data/di/ImageRetrofitModule.kt
@@ -1,6 +1,6 @@
 package com.ssavice.data.di
 
-import com.ssavice.data.service.ImageUploadService
+import com.ssavice.network.retrofit.service.ImageUploadService
 import com.ssavice.network.di.RetrofitModule
 import dagger.Module
 import dagger.Provides

--- a/core/data/src/main/java/com/ssavice/data/di/ImageRetrofitModule.kt
+++ b/core/data/src/main/java/com/ssavice/data/di/ImageRetrofitModule.kt
@@ -1,7 +1,7 @@
 package com.ssavice.data.di
 
-import com.ssavice.network.retrofit.service.ImageUploadService
 import com.ssavice.network.di.RetrofitModule
+import com.ssavice.network.retrofit.service.ImageUploadService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn

--- a/core/data/src/main/java/com/ssavice/data/di/KakaoRestRetrofitModule.kt
+++ b/core/data/src/main/java/com/ssavice/data/di/KakaoRestRetrofitModule.kt
@@ -1,7 +1,7 @@
 package com.ssavice.data.di
 
-import com.ssavice.network.retrofit.service.KakaoRestService
 import com.ssavice.network.di.RetrofitModule
+import com.ssavice.network.retrofit.service.KakaoRestService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn

--- a/core/data/src/main/java/com/ssavice/data/di/KakaoRestRetrofitModule.kt
+++ b/core/data/src/main/java/com/ssavice/data/di/KakaoRestRetrofitModule.kt
@@ -1,6 +1,6 @@
 package com.ssavice.data.di
 
-import com.ssavice.data.service.KakaoRestService
+import com.ssavice.network.retrofit.service.KakaoRestService
 import com.ssavice.network.di.RetrofitModule
 import dagger.Module
 import dagger.Provides

--- a/core/data/src/main/java/com/ssavice/data/di/ServiceRetrofitModule.kt
+++ b/core/data/src/main/java/com/ssavice/data/di/ServiceRetrofitModule.kt
@@ -1,9 +1,8 @@
 package com.ssavice.data.di
 
 import com.ssavice.data.repository.ServiceRepository
-import com.ssavice.data.repositoryimpl.DemoServiceRepository
 import com.ssavice.data.repositoryimpl.RemoteServiceRepository
-import com.ssavice.data.service.ServiceRetrofitService
+import com.ssavice.network.retrofit.service.ServiceRetrofitService
 import com.ssavice.network.di.RetrofitModule
 import dagger.Binds
 import dagger.Module

--- a/core/data/src/main/java/com/ssavice/data/di/ServiceRetrofitModule.kt
+++ b/core/data/src/main/java/com/ssavice/data/di/ServiceRetrofitModule.kt
@@ -2,8 +2,8 @@ package com.ssavice.data.di
 
 import com.ssavice.data.repository.ServiceRepository
 import com.ssavice.data.repositoryimpl.RemoteServiceRepository
-import com.ssavice.network.retrofit.service.ServiceRetrofitService
 import com.ssavice.network.di.RetrofitModule
+import com.ssavice.network.retrofit.service.ServiceRetrofitService
 import dagger.Binds
 import dagger.Module
 import dagger.Provides

--- a/core/data/src/main/java/com/ssavice/data/di/UserInfoModule.kt
+++ b/core/data/src/main/java/com/ssavice/data/di/UserInfoModule.kt
@@ -2,7 +2,7 @@ package com.ssavice.data.di
 
 import com.ssavice.data.repository.UserInfoRepository
 import com.ssavice.data.repositoryimpl.RemoteUserInfoRepository
-import com.ssavice.data.service.UserInfoRetrofitService
+import com.ssavice.network.retrofit.service.UserInfoRetrofitService
 import com.ssavice.network.di.RetrofitModule
 import dagger.Binds
 import dagger.Module

--- a/core/data/src/main/java/com/ssavice/data/di/UserInfoModule.kt
+++ b/core/data/src/main/java/com/ssavice/data/di/UserInfoModule.kt
@@ -2,8 +2,8 @@ package com.ssavice.data.di
 
 import com.ssavice.data.repository.UserInfoRepository
 import com.ssavice.data.repositoryimpl.RemoteUserInfoRepository
-import com.ssavice.network.retrofit.service.UserInfoRetrofitService
 import com.ssavice.network.di.RetrofitModule
+import com.ssavice.network.retrofit.service.UserInfoRetrofitService
 import dagger.Binds
 import dagger.Module
 import dagger.Provides

--- a/core/data/src/main/java/com/ssavice/data/repositoryimpl/RemoteSellerInfoRepository.kt
+++ b/core/data/src/main/java/com/ssavice/data/repositoryimpl/RemoteSellerInfoRepository.kt
@@ -2,8 +2,6 @@ package com.ssavice.data.repositoryimpl
 
 import android.util.Log
 import com.ssavice.data.repository.SellerInfoRepository
-import com.ssavice.network.retrofit.service.CompanyRetrofitService
-import com.ssavice.network.retrofit.service.ImageUploadService
 import com.ssavice.model.Date
 import com.ssavice.model.ImageUploadProgress
 import com.ssavice.model.Region
@@ -27,6 +25,8 @@ import com.ssavice.network.model.ContentTypeDTO
 import com.ssavice.network.model.company.AddCompanyDTO
 import com.ssavice.network.model.company.UpdateCompanyProfileDTO
 import com.ssavice.network.model.company.ValidateBusinessDTO
+import com.ssavice.network.retrofit.service.CompanyRetrofitService
+import com.ssavice.network.retrofit.service.ImageUploadService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow

--- a/core/data/src/main/java/com/ssavice/data/repositoryimpl/RemoteSellerInfoRepository.kt
+++ b/core/data/src/main/java/com/ssavice/data/repositoryimpl/RemoteSellerInfoRepository.kt
@@ -2,8 +2,8 @@ package com.ssavice.data.repositoryimpl
 
 import android.util.Log
 import com.ssavice.data.repository.SellerInfoRepository
-import com.ssavice.data.service.CompanyRetrofitService
-import com.ssavice.data.service.ImageUploadService
+import com.ssavice.network.retrofit.service.CompanyRetrofitService
+import com.ssavice.network.retrofit.service.ImageUploadService
 import com.ssavice.model.Date
 import com.ssavice.model.ImageUploadProgress
 import com.ssavice.model.Region

--- a/core/data/src/main/java/com/ssavice/data/repositoryimpl/RemoteServiceRepository.kt
+++ b/core/data/src/main/java/com/ssavice/data/repositoryimpl/RemoteServiceRepository.kt
@@ -2,8 +2,8 @@ package com.ssavice.data.repositoryimpl
 
 import android.util.Log
 import com.ssavice.data.repository.ServiceRepository
-import com.ssavice.data.service.ImageUploadService
-import com.ssavice.data.service.ServiceRetrofitService
+import com.ssavice.network.retrofit.service.ImageUploadService
+import com.ssavice.network.retrofit.service.ServiceRetrofitService
 import com.ssavice.model.ImageUploadProgress
 import com.ssavice.model.ResizableImage
 import com.ssavice.model.service.ReviewForm

--- a/core/data/src/main/java/com/ssavice/data/repositoryimpl/RemoteServiceRepository.kt
+++ b/core/data/src/main/java/com/ssavice/data/repositoryimpl/RemoteServiceRepository.kt
@@ -2,8 +2,6 @@ package com.ssavice.data.repositoryimpl
 
 import android.util.Log
 import com.ssavice.data.repository.ServiceRepository
-import com.ssavice.network.retrofit.service.ImageUploadService
-import com.ssavice.network.retrofit.service.ServiceRetrofitService
 import com.ssavice.model.ImageUploadProgress
 import com.ssavice.model.ResizableImage
 import com.ssavice.model.service.ReviewForm
@@ -19,6 +17,8 @@ import com.ssavice.network.model.ImageUploadDTO
 import com.ssavice.network.model.review.PostReviewDTO
 import com.ssavice.network.model.service.AddServiceDTO
 import com.ssavice.network.model.service.SearchServiceDTO
+import com.ssavice.network.retrofit.service.ImageUploadService
+import com.ssavice.network.retrofit.service.ServiceRetrofitService
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import okhttp3.MediaType.Companion.toMediaTypeOrNull

--- a/core/data/src/main/java/com/ssavice/data/repositoryimpl/RemoteUserInfoRepository.kt
+++ b/core/data/src/main/java/com/ssavice/data/repositoryimpl/RemoteUserInfoRepository.kt
@@ -2,8 +2,8 @@ package com.ssavice.data.repositoryimpl
 
 import android.util.Log
 import com.ssavice.data.repository.UserInfoRepository
-import com.ssavice.data.service.ImageUploadService
-import com.ssavice.data.service.UserInfoRetrofitService
+import com.ssavice.network.retrofit.service.ImageUploadService
+import com.ssavice.network.retrofit.service.UserInfoRetrofitService
 import com.ssavice.model.Date
 import com.ssavice.model.ImageUploadProgress
 import com.ssavice.model.RegionDetail

--- a/core/data/src/main/java/com/ssavice/data/repositoryimpl/RemoteUserInfoRepository.kt
+++ b/core/data/src/main/java/com/ssavice/data/repositoryimpl/RemoteUserInfoRepository.kt
@@ -2,8 +2,6 @@ package com.ssavice.data.repositoryimpl
 
 import android.util.Log
 import com.ssavice.data.repository.UserInfoRepository
-import com.ssavice.network.retrofit.service.ImageUploadService
-import com.ssavice.network.retrofit.service.UserInfoRetrofitService
 import com.ssavice.model.Date
 import com.ssavice.model.ImageUploadProgress
 import com.ssavice.model.RegionDetail
@@ -22,6 +20,8 @@ import com.ssavice.network.model.ContentTypeDTO
 import com.ssavice.network.model.RegionPostDTO
 import com.ssavice.network.model.service.WishServiceDTO
 import com.ssavice.network.model.user.UpdateUserProfileDTO
+import com.ssavice.network.retrofit.service.ImageUploadService
+import com.ssavice.network.retrofit.service.UserInfoRetrofitService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow

--- a/core/datastore/src/main/kotlin/com/ssavice/datastore/di/ChattingMetadataModule.kt
+++ b/core/datastore/src/main/kotlin/com/ssavice/datastore/di/ChattingMetadataModule.kt
@@ -28,8 +28,9 @@ import javax.inject.Singleton
 abstract class ChattingMetadataModule {
     @Binds
     @Singleton
-    internal abstract fun bindChattingMetadataRepository
-                (localChattingMetadataRepository: LocalChattingMetadataRepository): ChattingMetadataRepository
+    internal abstract fun bindChattingMetadataRepository(
+        localChattingMetadataRepository: LocalChattingMetadataRepository,
+    ): ChattingMetadataRepository
 }
 
 @Module

--- a/core/datastore/src/main/kotlin/com/ssavice/datastore/di/ChattingMetadataModule.kt
+++ b/core/datastore/src/main/kotlin/com/ssavice/datastore/di/ChattingMetadataModule.kt
@@ -1,0 +1,57 @@
+package com.ssavice.datastore.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.DataStoreFactory
+import androidx.datastore.dataStoreFile
+import com.google.crypto.tink.Aead
+import com.ssavice.datastore.preferences.JwtPreferences
+import com.ssavice.datastore.preferences.JwtPreferencesSerializer
+import com.ssavice.datastore.preferences.ServiceMetadataPreferences
+import com.ssavice.datastore.preferences.ServiceMetadataPreferencesSerializer
+import com.ssavice.datastore.preferences.UserInfoPreferences
+import com.ssavice.datastore.preferences.UserInfoPreferencesSerializer
+import com.ssavice.datastore.repository.ChattingMetadataRepository
+import com.ssavice.datastore.repository.JwtRepository
+import com.ssavice.datastore.repositoryimpl.LocalChattingMetadataRepository
+import com.ssavice.datastore.repositoryimpl.LocalJwtRepository
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ChattingMetadataModule {
+    @Binds
+    @Singleton
+    internal abstract fun bindChattingMetadataRepository
+                (localChattingMetadataRepository: LocalChattingMetadataRepository): ChattingMetadataRepository
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object PreferencesModule {
+    @Provides
+    @Singleton
+    fun provideServiceMetadataPreference(
+        @ApplicationContext context: Context,
+    ): DataStore<ServiceMetadataPreferences> =
+        DataStoreFactory.create(
+            serializer = ServiceMetadataPreferencesSerializer,
+            produceFile = { context.dataStoreFile("service_meta_preferences.pb") },
+        )
+
+    @Provides
+    @Singleton
+    fun provideUserInfoPreference(
+        @ApplicationContext context: Context,
+    ): DataStore<UserInfoPreferences> =
+        DataStoreFactory.create(
+            serializer = UserInfoPreferencesSerializer,
+            produceFile = { context.dataStoreFile("user_info_preferences.pb") },
+        )
+}

--- a/core/datastore/src/main/kotlin/com/ssavice/datastore/preferences/ServiceMetadataPreferences.kt
+++ b/core/datastore/src/main/kotlin/com/ssavice/datastore/preferences/ServiceMetadataPreferences.kt
@@ -1,0 +1,39 @@
+package com.ssavice.datastore.preferences
+
+import androidx.datastore.core.Serializer
+import com.ssavice.model.chat.ChattingServiceSummary
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.Serializable
+import java.io.InputStream
+import java.io.OutputStream
+
+@Serializable
+data class ServiceMetadataPreferences(
+    val infos: Map<Long, ChattingServiceSummary> = emptyMap(),
+)
+
+object ServiceMetadataPreferencesSerializer : Serializer<ServiceMetadataPreferences> {
+
+    override val defaultValue: ServiceMetadataPreferences = ServiceMetadataPreferences()
+
+    override suspend fun readFrom(input: InputStream): ServiceMetadataPreferences {
+        return try {
+            Json.decodeFromString(
+                deserializer = ServiceMetadataPreferences.serializer(),
+                string = input.readBytes().decodeToString()
+            )
+        } catch (e: SerializationException) {
+            defaultValue
+        }
+    }
+
+    override suspend fun writeTo(t: ServiceMetadataPreferences, output: OutputStream) {
+        output.write(
+            Json.encodeToString(
+                serializer = ServiceMetadataPreferences.serializer(),
+                value = t
+            ).encodeToByteArray()
+        )
+    }
+}

--- a/core/datastore/src/main/kotlin/com/ssavice/datastore/preferences/ServiceMetadataPreferences.kt
+++ b/core/datastore/src/main/kotlin/com/ssavice/datastore/preferences/ServiceMetadataPreferences.kt
@@ -2,9 +2,9 @@ package com.ssavice.datastore.preferences
 
 import androidx.datastore.core.Serializer
 import com.ssavice.model.chat.ChattingServiceSummary
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.Serializable
 import java.io.InputStream
 import java.io.OutputStream
 
@@ -14,26 +14,28 @@ data class ServiceMetadataPreferences(
 )
 
 object ServiceMetadataPreferencesSerializer : Serializer<ServiceMetadataPreferences> {
-
     override val defaultValue: ServiceMetadataPreferences = ServiceMetadataPreferences()
 
-    override suspend fun readFrom(input: InputStream): ServiceMetadataPreferences {
-        return try {
+    override suspend fun readFrom(input: InputStream): ServiceMetadataPreferences =
+        try {
             Json.decodeFromString(
                 deserializer = ServiceMetadataPreferences.serializer(),
-                string = input.readBytes().decodeToString()
+                string = input.readBytes().decodeToString(),
             )
         } catch (e: SerializationException) {
             defaultValue
         }
-    }
 
-    override suspend fun writeTo(t: ServiceMetadataPreferences, output: OutputStream) {
+    override suspend fun writeTo(
+        t: ServiceMetadataPreferences,
+        output: OutputStream,
+    ) {
         output.write(
-            Json.encodeToString(
-                serializer = ServiceMetadataPreferences.serializer(),
-                value = t
-            ).encodeToByteArray()
+            Json
+                .encodeToString(
+                    serializer = ServiceMetadataPreferences.serializer(),
+                    value = t,
+                ).encodeToByteArray(),
         )
     }
 }

--- a/core/datastore/src/main/kotlin/com/ssavice/datastore/preferences/UserInfoPreferences.kt
+++ b/core/datastore/src/main/kotlin/com/ssavice/datastore/preferences/UserInfoPreferences.kt
@@ -10,30 +10,32 @@ import java.io.OutputStream
 
 @Serializable
 data class UserInfoPreferences(
-    val infos: Map<Long,ChattingUserInfo> = emptyMap(),
+    val infos: Map<Long, ChattingUserInfo> = emptyMap(),
 )
 
 object UserInfoPreferencesSerializer : Serializer<UserInfoPreferences> {
-
     override val defaultValue: UserInfoPreferences = UserInfoPreferences()
 
-    override suspend fun readFrom(input: InputStream): UserInfoPreferences {
-        return try {
+    override suspend fun readFrom(input: InputStream): UserInfoPreferences =
+        try {
             Json.decodeFromString(
                 deserializer = UserInfoPreferences.serializer(),
-                string = input.readBytes().decodeToString()
+                string = input.readBytes().decodeToString(),
             )
         } catch (e: SerializationException) {
             defaultValue
         }
-    }
 
-    override suspend fun writeTo(t: UserInfoPreferences, output: OutputStream) {
+    override suspend fun writeTo(
+        t: UserInfoPreferences,
+        output: OutputStream,
+    ) {
         output.write(
-            Json.encodeToString(
-                serializer = UserInfoPreferences.serializer(),
-                value = t
-            ).encodeToByteArray()
+            Json
+                .encodeToString(
+                    serializer = UserInfoPreferences.serializer(),
+                    value = t,
+                ).encodeToByteArray(),
         )
     }
 }

--- a/core/datastore/src/main/kotlin/com/ssavice/datastore/preferences/UserInfoPreferences.kt
+++ b/core/datastore/src/main/kotlin/com/ssavice/datastore/preferences/UserInfoPreferences.kt
@@ -1,0 +1,39 @@
+package com.ssavice.datastore.preferences
+
+import androidx.datastore.core.Serializer
+import com.ssavice.model.chat.ChattingUserInfo
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import java.io.InputStream
+import java.io.OutputStream
+
+@Serializable
+data class UserInfoPreferences(
+    val infos: Map<Long,ChattingUserInfo> = emptyMap(),
+)
+
+object UserInfoPreferencesSerializer : Serializer<UserInfoPreferences> {
+
+    override val defaultValue: UserInfoPreferences = UserInfoPreferences()
+
+    override suspend fun readFrom(input: InputStream): UserInfoPreferences {
+        return try {
+            Json.decodeFromString(
+                deserializer = UserInfoPreferences.serializer(),
+                string = input.readBytes().decodeToString()
+            )
+        } catch (e: SerializationException) {
+            defaultValue
+        }
+    }
+
+    override suspend fun writeTo(t: UserInfoPreferences, output: OutputStream) {
+        output.write(
+            Json.encodeToString(
+                serializer = UserInfoPreferences.serializer(),
+                value = t
+            ).encodeToByteArray()
+        )
+    }
+}

--- a/core/datastore/src/main/kotlin/com/ssavice/datastore/repository/ChattingMetadataRepository.kt
+++ b/core/datastore/src/main/kotlin/com/ssavice/datastore/repository/ChattingMetadataRepository.kt
@@ -1,0 +1,26 @@
+package com.ssavice.datastore.repository
+
+import com.ssavice.model.chat.ChattingServiceSummary
+import com.ssavice.model.chat.ChattingUserInfo
+import kotlinx.coroutines.flow.Flow
+
+interface ChattingMetadataRepository {
+    suspend fun getUserInfo(userId: Long): Result<ChattingUserInfo>
+
+    suspend fun getServiceSummary(serviceId: Long): Result<ChattingServiceSummary>
+
+    suspend fun setUserInfo(userInfo: ChattingUserInfo)
+
+    suspend fun setUserInfos(userInfos: List<ChattingUserInfo>)
+
+    suspend fun setServiceSummary(serviceSummary: ChattingServiceSummary)
+
+    suspend fun clearUserInfo()
+
+    suspend fun clearServiceSummary()
+
+    fun getUserInfoFlow(): Flow<Map<Long, ChattingUserInfo>>
+
+    fun getServiceSummaryFlow(): Flow<Map<Long, ChattingServiceSummary>>
+
+}

--- a/core/datastore/src/main/kotlin/com/ssavice/datastore/repository/ChattingMetadataRepository.kt
+++ b/core/datastore/src/main/kotlin/com/ssavice/datastore/repository/ChattingMetadataRepository.kt
@@ -22,5 +22,4 @@ interface ChattingMetadataRepository {
     fun getUserInfoFlow(): Flow<Map<Long, ChattingUserInfo>>
 
     fun getServiceSummaryFlow(): Flow<Map<Long, ChattingServiceSummary>>
-
 }

--- a/core/datastore/src/main/kotlin/com/ssavice/datastore/repositoryimpl/LocalChattingMetadataRepository.kt
+++ b/core/datastore/src/main/kotlin/com/ssavice/datastore/repositoryimpl/LocalChattingMetadataRepository.kt
@@ -13,91 +13,92 @@ import java.io.FileNotFoundException
 import javax.inject.Inject
 
 class LocalChattingMetadataRepository
-@Inject
-constructor(
-    private val serviceDataStore: DataStore<ServiceMetadataPreferences>,
-    private val userInfoDataStore: DataStore<UserInfoPreferences>
-) : ChattingMetadataRepository {
-    override suspend fun getUserInfo(userId: Long): Result<ChattingUserInfo> {
-        return try {
-            val data = userInfoDataStore.data.map {
-                it.infos[userId]
-            }.first()
+    @Inject
+    constructor(
+        private val serviceDataStore: DataStore<ServiceMetadataPreferences>,
+        private val userInfoDataStore: DataStore<UserInfoPreferences>,
+    ) : ChattingMetadataRepository {
+        override suspend fun getUserInfo(userId: Long): Result<ChattingUserInfo> =
+            try {
+                val data =
+                    userInfoDataStore.data
+                        .map {
+                            it.infos[userId]
+                        }.first()
 
-            if(data != null)
-                Result.success(data)
-            else
-                Result.failure(FileNotFoundException())
-        } catch (e: Exception) {
-            Result.failure(e)
+                if (data != null) {
+                    Result.success(data)
+                } else {
+                    Result.failure(FileNotFoundException())
+                }
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+        override suspend fun getServiceSummary(serviceId: Long): Result<ChattingServiceSummary> =
+            try {
+                val data =
+                    serviceDataStore.data
+                        .map {
+                            it.infos[serviceId]
+                        }.first()
+
+                if (data != null) {
+                    Result.success(data)
+                } else {
+                    Result.failure(FileNotFoundException())
+                }
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+        override suspend fun setUserInfo(userInfo: ChattingUserInfo) {
+            userInfoDataStore.updateData { preferences ->
+                preferences.copy(
+                    infos = preferences.infos + (userInfo.id to userInfo),
+                )
+            }
         }
-    }
 
-    override suspend fun getServiceSummary(serviceId: Long): Result<ChattingServiceSummary> {
-        return try {
-            val data = serviceDataStore.data.map {
-                it.infos[serviceId]
-            }.first()
-
-            if(data != null)
-                Result.success(data)
-            else
-                Result.failure(FileNotFoundException())
-
-        } catch (e: Exception) {
-            Result.failure(e)
+        override suspend fun setUserInfos(userInfos: List<ChattingUserInfo>) {
+            userInfoDataStore.updateData { preferences ->
+                preferences.copy(
+                    infos = userInfos.associateBy { it.id },
+                )
+            }
         }
-    }
 
-    override suspend fun setUserInfo(userInfo: ChattingUserInfo) {
-        userInfoDataStore.updateData { preferences ->
-            preferences.copy(
-                infos = preferences.infos + (userInfo.id to userInfo)
-            )
+        override suspend fun setServiceSummary(serviceSummary: ChattingServiceSummary) {
+            serviceDataStore.updateData {
+                it.copy(
+                    infos = it.infos + (serviceSummary.serviceId to serviceSummary),
+                )
+            }
         }
-    }
 
-    override suspend fun setUserInfos(userInfos: List<ChattingUserInfo>) {
-        userInfoDataStore.updateData { preferences ->
-            preferences.copy(
-                infos = userInfos.associateBy { it.id }
-            )
+        override suspend fun clearUserInfo() {
+            userInfoDataStore.updateData {
+                it.copy(
+                    infos = mapOf(),
+                )
+            }
         }
-    }
 
-    override suspend fun setServiceSummary(serviceSummary: ChattingServiceSummary) {
-        serviceDataStore.updateData {
-            it.copy(
-                infos = it.infos + (serviceSummary.serviceId to serviceSummary)
-            )
+        override suspend fun clearServiceSummary() {
+            serviceDataStore.updateData {
+                it.copy(
+                    infos = mapOf(),
+                )
+            }
         }
-    }
 
-    override suspend fun clearUserInfo() {
-        userInfoDataStore.updateData {
-            it.copy(
-                infos = mapOf()
-            )
-        }
-    }
+        override fun getUserInfoFlow(): Flow<Map<Long, ChattingUserInfo>> =
+            userInfoDataStore.data.map {
+                it.infos
+            }
 
-    override suspend fun clearServiceSummary() {
-        serviceDataStore.updateData {
-            it.copy(
-                infos = mapOf()
-            )
-        }
+        override fun getServiceSummaryFlow(): Flow<Map<Long, ChattingServiceSummary>> =
+            serviceDataStore.data.map {
+                it.infos
+            }
     }
-
-    override fun getUserInfoFlow(): Flow<Map<Long, ChattingUserInfo>> {
-        return userInfoDataStore.data.map {
-            it.infos
-        }
-    }
-
-    override fun getServiceSummaryFlow(): Flow<Map<Long, ChattingServiceSummary>> {
-        return serviceDataStore.data.map {
-            it.infos
-        }
-    }
-}

--- a/core/datastore/src/main/kotlin/com/ssavice/datastore/repositoryimpl/LocalChattingMetadataRepository.kt
+++ b/core/datastore/src/main/kotlin/com/ssavice/datastore/repositoryimpl/LocalChattingMetadataRepository.kt
@@ -1,0 +1,103 @@
+package com.ssavice.datastore.repositoryimpl
+
+import androidx.datastore.core.DataStore
+import com.ssavice.datastore.preferences.ServiceMetadataPreferences
+import com.ssavice.datastore.preferences.UserInfoPreferences
+import com.ssavice.datastore.repository.ChattingMetadataRepository
+import com.ssavice.model.chat.ChattingServiceSummary
+import com.ssavice.model.chat.ChattingUserInfo
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import java.io.FileNotFoundException
+import javax.inject.Inject
+
+class LocalChattingMetadataRepository
+@Inject
+constructor(
+    private val serviceDataStore: DataStore<ServiceMetadataPreferences>,
+    private val userInfoDataStore: DataStore<UserInfoPreferences>
+) : ChattingMetadataRepository {
+    override suspend fun getUserInfo(userId: Long): Result<ChattingUserInfo> {
+        return try {
+            val data = userInfoDataStore.data.map {
+                it.infos[userId]
+            }.first()
+
+            if(data != null)
+                Result.success(data)
+            else
+                Result.failure(FileNotFoundException())
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun getServiceSummary(serviceId: Long): Result<ChattingServiceSummary> {
+        return try {
+            val data = serviceDataStore.data.map {
+                it.infos[serviceId]
+            }.first()
+
+            if(data != null)
+                Result.success(data)
+            else
+                Result.failure(FileNotFoundException())
+
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun setUserInfo(userInfo: ChattingUserInfo) {
+        userInfoDataStore.updateData { preferences ->
+            preferences.copy(
+                infos = preferences.infos + (userInfo.id to userInfo)
+            )
+        }
+    }
+
+    override suspend fun setUserInfos(userInfos: List<ChattingUserInfo>) {
+        userInfoDataStore.updateData { preferences ->
+            preferences.copy(
+                infos = userInfos.associateBy { it.id }
+            )
+        }
+    }
+
+    override suspend fun setServiceSummary(serviceSummary: ChattingServiceSummary) {
+        serviceDataStore.updateData {
+            it.copy(
+                infos = it.infos + (serviceSummary.serviceId to serviceSummary)
+            )
+        }
+    }
+
+    override suspend fun clearUserInfo() {
+        userInfoDataStore.updateData {
+            it.copy(
+                infos = mapOf()
+            )
+        }
+    }
+
+    override suspend fun clearServiceSummary() {
+        serviceDataStore.updateData {
+            it.copy(
+                infos = mapOf()
+            )
+        }
+    }
+
+    override fun getUserInfoFlow(): Flow<Map<Long, ChattingUserInfo>> {
+        return userInfoDataStore.data.map {
+            it.infos
+        }
+    }
+
+    override fun getServiceSummaryFlow(): Flow<Map<Long, ChattingServiceSummary>> {
+        return serviceDataStore.data.map {
+            it.infos
+        }
+    }
+}

--- a/core/model/src/main/java/com/ssavice/model/Date.kt
+++ b/core/model/src/main/java/com/ssavice/model/Date.kt
@@ -45,7 +45,7 @@ data class DateTime(
         val localDateTime = LocalDateTime.of(year, month, day, hour, minute)
         return localDateTime.format(chatTimeFormatter)
     }
-    
+
     fun absoluteDateSimpleString(): String {
         val now = LocalDateTime.now(DEFAULT_TIME_ZONE.toZoneId())
 

--- a/core/model/src/main/java/com/ssavice/model/Date.kt
+++ b/core/model/src/main/java/com/ssavice/model/Date.kt
@@ -45,6 +45,22 @@ data class DateTime(
         val localDateTime = LocalDateTime.of(year, month, day, hour, minute)
         return localDateTime.format(chatTimeFormatter)
     }
+    
+    fun absoluteDateSimpleString(): String {
+        val now = LocalDateTime.now(DEFAULT_TIME_ZONE.toZoneId())
+
+        return if (now.year == this.year) {
+            // 올해인 경우: M월 d일
+            this.toTimeStamp().let {
+                val ldt = LocalDateTime.of(year, month, day, hour, minute)
+                ldt.format(absoluteMonthDayFormatter)
+            }
+        } else {
+            // 올해가 아닌 경우: yyyy년 M월 d일
+            val ldt = LocalDateTime.of(year, month, day, hour, minute)
+            ldt.format(absoluteYearMonthDayFormatter)
+        }
+    }
 
     fun dateToSimpleString(): String {
         val now = LocalDateTime.now(DEFAULT_TIME_ZONE.toZoneId())
@@ -97,6 +113,16 @@ data class DateTime(
         val yearMonthDayFormatter: java.time.format.DateTimeFormatter =
             java.time.format.DateTimeFormatter
                 .ofPattern("yyyy. M. d.", Locale.getDefault())
+
+        @Suppress("ConstantLocale")
+        val absoluteMonthDayFormatter: java.time.format.DateTimeFormatter =
+            java.time.format.DateTimeFormatter
+                .ofPattern("M월 d일", Locale.getDefault())
+
+        @Suppress("ConstantLocale")
+        val absoluteYearMonthDayFormatter: java.time.format.DateTimeFormatter =
+            java.time.format.DateTimeFormatter
+                .ofPattern("yyyy년 M월 d일", Locale.getDefault())
     }
 }
 

--- a/core/model/src/main/java/com/ssavice/model/chat/ChattingRoomInfo.kt
+++ b/core/model/src/main/java/com/ssavice/model/chat/ChattingRoomInfo.kt
@@ -7,10 +7,5 @@ data class ChattingRoomInfo(
     val name: String,
     val roomType: RoomType,
     val serviceId: Long,
-)
-
-data class ChattingRoomParticipant(
-    val name: String,
-    val userId: Long,
-    val thumbnail: String,
+    val participantIds: List<Long>
 )

--- a/core/model/src/main/java/com/ssavice/model/chat/ChattingRoomInfo.kt
+++ b/core/model/src/main/java/com/ssavice/model/chat/ChattingRoomInfo.kt
@@ -7,5 +7,5 @@ data class ChattingRoomInfo(
     val name: String,
     val roomType: RoomType,
     val serviceId: Long,
-    val participantIds: List<Long>
+    val participantIds: List<Long>,
 )

--- a/core/model/src/main/java/com/ssavice/model/chat/ChattingServiceSummary.kt
+++ b/core/model/src/main/java/com/ssavice/model/chat/ChattingServiceSummary.kt
@@ -1,0 +1,21 @@
+package com.ssavice.model.chat
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ChattingServiceSummary(
+    val serviceId: Long,
+    val serviceName: String,
+    val servicePrice: Int,
+    val serviceThumbnail: String,
+    val serviceSeller: String,
+    val lastUpdate: Long = System.currentTimeMillis()
+) {
+    fun needRefresh(): Boolean {
+        return (System.currentTimeMillis() - lastUpdate) > SERVICE_SUMMARY_REFRESH_CYCLE
+    }
+
+    companion object {
+        const val SERVICE_SUMMARY_REFRESH_CYCLE = 1000 * 3600 * 6
+    }
+}

--- a/core/model/src/main/java/com/ssavice/model/chat/ChattingServiceSummary.kt
+++ b/core/model/src/main/java/com/ssavice/model/chat/ChattingServiceSummary.kt
@@ -9,11 +9,9 @@ data class ChattingServiceSummary(
     val servicePrice: Int,
     val serviceThumbnail: String,
     val serviceSeller: String,
-    val lastUpdate: Long = System.currentTimeMillis()
+    val lastUpdate: Long = System.currentTimeMillis(),
 ) {
-    fun needRefresh(): Boolean {
-        return (System.currentTimeMillis() - lastUpdate) > SERVICE_SUMMARY_REFRESH_CYCLE
-    }
+    fun needRefresh(): Boolean = (System.currentTimeMillis() - lastUpdate) > SERVICE_SUMMARY_REFRESH_CYCLE
 
     companion object {
         const val SERVICE_SUMMARY_REFRESH_CYCLE = 1000 * 3600 * 6

--- a/core/model/src/main/java/com/ssavice/model/chat/ChattingUserInfo.kt
+++ b/core/model/src/main/java/com/ssavice/model/chat/ChattingUserInfo.kt
@@ -1,0 +1,19 @@
+package com.ssavice.model.chat
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ChattingUserInfo(
+    val name: String,
+    val id: Long,
+    val thumbnail: String,
+    val lastUpdate: Long = System.currentTimeMillis()
+) {
+    fun needRefresh(): Boolean {
+        return (System.currentTimeMillis() - lastUpdate) > USER_INFO_REFRESH_CYCLE
+    }
+
+    companion object {
+        const val USER_INFO_REFRESH_CYCLE = 1000 * 3600 * 2
+    }
+}

--- a/core/model/src/main/java/com/ssavice/model/chat/ChattingUserInfo.kt
+++ b/core/model/src/main/java/com/ssavice/model/chat/ChattingUserInfo.kt
@@ -7,11 +7,9 @@ data class ChattingUserInfo(
     val name: String,
     val id: Long,
     val thumbnail: String,
-    val lastUpdate: Long = System.currentTimeMillis()
+    val lastUpdate: Long = System.currentTimeMillis(),
 ) {
-    fun needRefresh(): Boolean {
-        return (System.currentTimeMillis() - lastUpdate) > USER_INFO_REFRESH_CYCLE
-    }
+    fun needRefresh(): Boolean = (System.currentTimeMillis() - lastUpdate) > USER_INFO_REFRESH_CYCLE
 
     companion object {
         const val USER_INFO_REFRESH_CYCLE = 1000 * 3600 * 2

--- a/core/network/src/main/kotlin/com/ssavice/network/di/RetrofitModule.kt
+++ b/core/network/src/main/kotlin/com/ssavice/network/di/RetrofitModule.kt
@@ -96,8 +96,11 @@ object RetrofitModule {
     @Provides
     @Singleton
     @ImageRetrofit
-    fun provideImageRetrofitBuilder(builder: Retrofit.Builder): Retrofit =
-        builder
+    fun provideImageRetrofitBuilder(callAdapterFactory: ResultCallAdapterFactory): Retrofit =
+        Retrofit
+            .Builder()
+            .addConverterFactory(retroJson.asConverterFactory("application/json".toMediaType()))
+            .addCallAdapterFactory(callAdapterFactory)
             .baseUrl(BuildConfig.BACKEND_URL)
             .build()
 

--- a/core/network/src/main/kotlin/com/ssavice/network/model/service/GetChatServiceSummaryDTO.kt
+++ b/core/network/src/main/kotlin/com/ssavice/network/model/service/GetChatServiceSummaryDTO.kt
@@ -8,13 +8,14 @@ data class GetChatServiceSummaryDTO(
     val serviceName: String,
     val servicePrice: Int,
     val serviceThumbnail: String,
-    val serviceSeller: String
+    val serviceSeller: String,
 ) {
-    fun toModel(id: Long) = ChattingServiceSummary(
-        serviceId = id,
-        serviceName = serviceName,
-        servicePrice = servicePrice,
-        serviceThumbnail = serviceThumbnail,
-        serviceSeller = serviceSeller
-    )
+    fun toModel(id: Long) =
+        ChattingServiceSummary(
+            serviceId = id,
+            serviceName = serviceName,
+            servicePrice = servicePrice,
+            serviceThumbnail = serviceThumbnail,
+            serviceSeller = serviceSeller,
+        )
 }

--- a/core/network/src/main/kotlin/com/ssavice/network/model/service/GetChatServiceSummaryDTO.kt
+++ b/core/network/src/main/kotlin/com/ssavice/network/model/service/GetChatServiceSummaryDTO.kt
@@ -1,0 +1,20 @@
+package com.ssavice.network.model.service
+
+import com.ssavice.model.chat.ChattingServiceSummary
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetChatServiceSummaryDTO(
+    val serviceName: String,
+    val servicePrice: Int,
+    val serviceThumbnail: String,
+    val serviceSeller: String
+) {
+    fun toModel(id: Long) = ChattingServiceSummary(
+        serviceId = id,
+        serviceName = serviceName,
+        servicePrice = servicePrice,
+        serviceThumbnail = serviceThumbnail,
+        serviceSeller = serviceSeller
+    )
+}

--- a/core/network/src/main/kotlin/com/ssavice/network/model/user/GetMyIdDTO.kt
+++ b/core/network/src/main/kotlin/com/ssavice/network/model/user/GetMyIdDTO.kt
@@ -4,5 +4,5 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class GetMyIdDTO(
-    val id: Long
+    val id: Long,
 )

--- a/core/network/src/main/kotlin/com/ssavice/network/model/user/GetMyIdDTO.kt
+++ b/core/network/src/main/kotlin/com/ssavice/network/model/user/GetMyIdDTO.kt
@@ -1,0 +1,8 @@
+package com.ssavice.network.model.user
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetMyIdDTO(
+    val id: Long
+)

--- a/core/network/src/main/kotlin/com/ssavice/network/model/user/GetUserInfoDTO.kt
+++ b/core/network/src/main/kotlin/com/ssavice/network/model/user/GetUserInfoDTO.kt
@@ -5,22 +5,21 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class GetUserInfoDTO(
-    val list: List<UserInfoDTO>
+    val list: List<UserInfoDTO>,
 ) {
-    fun toModel(): List<ChattingUserInfo> {
-        return list.map {
+    fun toModel(): List<ChattingUserInfo> =
+        list.map {
             ChattingUserInfo(
                 name = it.name,
                 id = it.id,
-                thumbnail = it.thumbnail
+                thumbnail = it.thumbnail,
             )
         }
-    }
 }
 
 @Serializable
 data class UserInfoDTO(
     val name: String,
     val id: Long,
-    val thumbnail: String
+    val thumbnail: String,
 )

--- a/core/network/src/main/kotlin/com/ssavice/network/model/user/GetUserInfoDTO.kt
+++ b/core/network/src/main/kotlin/com/ssavice/network/model/user/GetUserInfoDTO.kt
@@ -1,0 +1,26 @@
+package com.ssavice.network.model.user
+
+import com.ssavice.model.chat.ChattingUserInfo
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetUserInfoDTO(
+    val list: List<UserInfoDTO>
+) {
+    fun toModel(): List<ChattingUserInfo> {
+        return list.map {
+            ChattingUserInfo(
+                name = it.name,
+                id = it.id,
+                thumbnail = it.thumbnail
+            )
+        }
+    }
+}
+
+@Serializable
+data class UserInfoDTO(
+    val name: String,
+    val id: Long,
+    val thumbnail: String
+)

--- a/core/network/src/main/kotlin/com/ssavice/network/retrofit/service/CompanyRetrofitService.kt
+++ b/core/network/src/main/kotlin/com/ssavice/network/retrofit/service/CompanyRetrofitService.kt
@@ -1,4 +1,4 @@
-package com.ssavice.data.service
+package com.ssavice.network.retrofit.service
 
 import GetCompanyInfoDTO
 import com.ssavice.network.model.ConfirmImageDTO
@@ -16,7 +16,6 @@ import com.ssavice.network.model.company.UpdateCompanyProfileDTO
 import com.ssavice.network.model.company.ValidateBusinessDTO
 import com.ssavice.network.model.company.ValidateBusinessResponseDTO
 import com.ssavice.network.model.review.GetCompanyReviewDTO
-import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST

--- a/core/network/src/main/kotlin/com/ssavice/network/retrofit/service/ImageUploadService.kt
+++ b/core/network/src/main/kotlin/com/ssavice/network/retrofit/service/ImageUploadService.kt
@@ -1,7 +1,6 @@
-package com.ssavice.data.service
+package com.ssavice.network.retrofit.service
 
 import okhttp3.RequestBody
-import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Header
 import retrofit2.http.PUT

--- a/core/network/src/main/kotlin/com/ssavice/network/retrofit/service/KakaoRestService.kt
+++ b/core/network/src/main/kotlin/com/ssavice/network/retrofit/service/KakaoRestService.kt
@@ -1,7 +1,6 @@
-package com.ssavice.data.service
+package com.ssavice.network.retrofit.service
 
 import com.ssavice.network.model.KakaoGetCoordinateDTO
-import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Path

--- a/core/network/src/main/kotlin/com/ssavice/network/retrofit/service/ServiceRetrofitService.kt
+++ b/core/network/src/main/kotlin/com/ssavice/network/retrofit/service/ServiceRetrofitService.kt
@@ -1,4 +1,4 @@
-package com.ssavice.data.service
+package com.ssavice.network.retrofit.service
 
 import com.ssavice.network.model.ImageUploadDTO
 import com.ssavice.network.model.PresignedUrlResponseDTO
@@ -6,10 +6,10 @@ import com.ssavice.network.model.review.PostReviewDTO
 import com.ssavice.network.model.service.AddServiceDTO
 import com.ssavice.network.model.service.AddServiceResponseDTO
 import com.ssavice.network.model.service.ApplyServiceResultDTO
+import com.ssavice.network.model.service.GetChatServiceSummaryDTO
 import com.ssavice.network.model.service.GetServiceDetailDTO
 import com.ssavice.network.model.service.GetServiceParticipantDTO
 import com.ssavice.network.model.service.SearchServiceResponseDTO
-import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -65,4 +65,9 @@ interface ServiceRetrofitService {
         @Query("size") size: Int,
         @Query("page") page: Int,
     ): Result<GetServiceParticipantDTO>
+
+    @GET("/api/service/book/{id}")
+    suspend fun getServiceSummary(
+        @Path(value = "id") id: Long,
+    ): Result<GetChatServiceSummaryDTO>
 }

--- a/core/network/src/main/kotlin/com/ssavice/network/retrofit/service/UserInfoRetrofitService.kt
+++ b/core/network/src/main/kotlin/com/ssavice/network/retrofit/service/UserInfoRetrofitService.kt
@@ -72,7 +72,7 @@ interface UserInfoRetrofitService {
 
     @GET("/api/user/info")
     suspend fun getUserInfoSummary(
-        @Query("ids")userIds: List<Long>
+        @Query("ids")userIds: List<Long>,
     ): Result<GetUserInfoDTO>
 
     @GET("/api/user/id")

--- a/core/network/src/main/kotlin/com/ssavice/network/retrofit/service/UserInfoRetrofitService.kt
+++ b/core/network/src/main/kotlin/com/ssavice/network/retrofit/service/UserInfoRetrofitService.kt
@@ -1,4 +1,4 @@
-package com.ssavice.data.service
+package com.ssavice.network.retrofit.service
 
 import com.ssavice.network.model.ConfirmImageDTO
 import com.ssavice.network.model.ContentTypeDTO
@@ -7,6 +7,8 @@ import com.ssavice.network.model.PresignedUrlDTO
 import com.ssavice.network.model.RegionPostDTO
 import com.ssavice.network.model.service.UserBookDTO
 import com.ssavice.network.model.service.WishServiceDTO
+import com.ssavice.network.model.user.GetMyIdDTO
+import com.ssavice.network.model.user.GetUserInfoDTO
 import com.ssavice.network.model.user.UpdateUserProfileDTO
 import com.ssavice.network.model.user.UpdateUserProfileResponseDTO
 import com.ssavice.network.model.user.UserBookSummaryDTO
@@ -67,4 +69,12 @@ interface UserInfoRetrofitService {
         @Query("page") page: Int,
         @Query("size") size: Int,
     ): Result<WishListDTO>
+
+    @GET("/api/user/info")
+    suspend fun getUserInfoSummary(
+        @Query("ids")userIds: List<Long>
+    ): Result<GetUserInfoDTO>
+
+    @GET("/api/user/id")
+    suspend fun getMyUserId(): Result<GetMyIdDTO>
 }

--- a/feature/chat/src/main/kotlin/com/ssavice/chat/ChatScreen.kt
+++ b/feature/chat/src/main/kotlin/com/ssavice/chat/ChatScreen.kt
@@ -49,10 +49,13 @@ fun ChatRoute(
         }
 
     LaunchedEffect(
-        roomUiState
+        roomUiState,
     ) {
-        when(roomUiState.chattingRoomState) {
-            ChattingRoomState.Initial -> viewModel.getYourId()
+        when (roomUiState.chattingRoomState) {
+            ChattingRoomState.Initial -> {
+                viewModel.getYourId()
+            }
+
             else -> {}
         }
     }
@@ -141,17 +144,21 @@ fun ChattingScreen(
                             true
                         } else {
                             (message.userId != before.userId) ||
-                                    message.time != before.time
+                                message.time != before.time
                         }
 
                     val insertDayDivider =
-                        if (before == null) false
-                        else (before.time.day != message.time.day ||
-                                before.time.month != message.time.month ||
-                                before.time.year != message.time.year
-                                )
+                        if (before == null) {
+                            false
+                        } else {
+                            (
+                                before.time.day != message.time.day ||
+                                    before.time.month != message.time.month ||
+                                    before.time.year != message.time.year
+                            )
+                        }
 
-                    if(last||insertDayDivider) {
+                    if (last || insertDayDivider) {
                         ChatDivider(
                             message = message.time.absoluteDateSimpleString(),
                         )

--- a/feature/chat/src/main/kotlin/com/ssavice/chat/ChatScreen.kt
+++ b/feature/chat/src/main/kotlin/com/ssavice/chat/ChatScreen.kt
@@ -36,7 +36,8 @@ fun ChatRoute(
     modifier: Modifier = Modifier,
     viewModel: ChattingViewModel = hiltViewModel(),
 ) {
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val roomUiState by viewModel.roomUiState.collectAsStateWithLifecycle()
+    val chattingState by viewModel.chattingUiState.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
     val imageRequestBuilder =
@@ -47,11 +48,19 @@ fun ChatRoute(
                 .crossfade(true)
         }
 
+    LaunchedEffect(
+        roomUiState
+    ) {
+        when(roomUiState.chattingRoomState) {
+            ChattingRoomState.Initial -> viewModel.getYourId()
+            else -> {}
+        }
+    }
+
     Box(modifier = modifier.fillMaxSize()) {
-        if (uiState.sendingService) {
-            viewModel.requestServiceInfo(uiState.serviceIdToSend)
+        if (roomUiState.sendingService) {
             SendServicePreviewItem(
-                serviceInfo = uiState.serviceInfo[uiState.serviceIdToSend],
+                serviceInfo = chattingState.serviceInfo[roomUiState.serviceIdToSend],
                 imageRequestBuilder = imageRequestBuilder,
                 modifier =
                     Modifier
@@ -62,11 +71,12 @@ fun ChatRoute(
             )
         }
 
-        if (uiState.chattingRoomState != ChattingRoomState.Pending) {
+        if (roomUiState.chattingRoomState == ChattingRoomState.Ready) {
             ChattingScreen(
                 modifier = Modifier,
                 viewModel = viewModel,
-                uiState = uiState,
+                roomUiState = roomUiState,
+                chattingUiState = chattingState,
                 imageRequestBuilder = imageRequestBuilder,
             )
         }
@@ -77,7 +87,8 @@ fun ChatRoute(
 fun ChattingScreen(
     modifier: Modifier = Modifier,
     viewModel: ChattingViewModel,
-    uiState: ChattingRoomUiState,
+    chattingUiState: ChattingDataUiState,
+    roomUiState: RoomUiState,
     imageRequestBuilder: ImageRequest.Builder,
 ) {
     val chatMessages: (LazyPagingItems<ChatMessage>) =
@@ -100,8 +111,8 @@ fun ChattingScreen(
         }
     }
 
-    LaunchedEffect(uiState.roomInfoLoadState) {
-        if (uiState.roomInfoLoadState == ChattingRoomInfoLoadState.Initial) {
+    LaunchedEffect(roomUiState.roomInfoLoadState) {
+        if (roomUiState.roomInfoLoadState == ChattingRoomInfoLoadState.Initial) {
             viewModel.loadChattingRoomInfo()
         }
     }
@@ -147,7 +158,7 @@ fun ChattingScreen(
                     }
                     when (val t = message) {
                         is ChatMessage.ServiceMessage -> {
-                            val service = uiState.serviceInfo[t.serviceId]
+                            val service = chattingUiState.serviceInfo[t.serviceId]
 
                             if (service == null) {
                                 ChatServiceShimmerBubble(
@@ -157,10 +168,10 @@ fun ChattingScreen(
                                 )
                             } else {
                                 ChatServiceBubble(
-                                    serviceTitle = service.name,
-                                    sellerName = service.seller,
-                                    price = "₩%,d".format(service.discountPrice),
-                                    thumbnailUrl = service.thumbnail,
+                                    serviceTitle = service.serviceName,
+                                    sellerName = service.serviceSeller,
+                                    price = "₩%,d".format(service.servicePrice),
+                                    thumbnailUrl = service.serviceThumbnail,
                                     direction = if (t.you) ChatBubbleDirection.SENT else ChatBubbleDirection.RECEIVED,
                                     timestamp = t.time.timeToSimpleString(),
                                     imageRequest = imageRequestBuilder,

--- a/feature/chat/src/main/kotlin/com/ssavice/chat/ChatScreen.kt
+++ b/feature/chat/src/main/kotlin/com/ssavice/chat/ChatScreen.kt
@@ -1,23 +1,12 @@
 package com.ssavice.chat
 
 import android.annotation.SuppressLint
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -25,27 +14,21 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
-import coil.compose.AsyncImage
 import coil.decode.SvgDecoder
 import coil.request.ImageRequest
-import com.ssavice.designsystem.component.ChatBubble
+import com.ssavice.chat.ui.ChatDivider
+import com.ssavice.chat.ui.ChatMessageItem
+import com.ssavice.chat.ui.SendServicePreviewItem
 import com.ssavice.designsystem.component.ChatBubbleDirection
-import com.ssavice.designsystem.component.ChatBubbleType
 import com.ssavice.designsystem.component.ChatServiceBubble
 import com.ssavice.designsystem.component.ChatServiceShimmerBubble
-import com.ssavice.designsystem.theme.shimmerBrush
-import com.ssavice.model.DateTime
 
 @SuppressLint("FrequentlyChangingValue")
 @Composable
@@ -134,203 +117,75 @@ fun ChattingScreen(
                 count = chatMessages.itemCount,
                 key = chatMessages.itemKey { it.messageId },
             ) { index ->
-                val message = chatMessages[index]
-                val before =
-                    if (index == chatMessages.itemCount - 1) null else chatMessages.peek(index + 1)
+                Column {
+                    val message = chatMessages[index]
+                    val before =
+                        if (index == chatMessages.itemCount - 1) null else chatMessages.peek(index + 1)
+                    val last = (index == chatMessages.itemCount - 1)
 
-                if (message == null) return@items
+                    if (message == null) return@items
 
-                val full =
-                    if (before == null) {
-                        true
-                    } else {
-                        (message.userId != before.userId) ||
-                            message.time != before.time
-                    }
-
-                when (val t = message) {
-                    is ChatMessage.ServiceMessage -> {
-                        val service = uiState.serviceInfo[t.serviceId]
-
-                        if (service == null) {
-                            ChatServiceShimmerBubble(
-                                direction = if (t.you) ChatBubbleDirection.SENT else ChatBubbleDirection.RECEIVED,
-                                timestamp = t.time.timeToSimpleString(),
-                                isEnd = true,
-                            )
+                    val full =
+                        if (before == null) {
+                            true
                         } else {
-                            ChatServiceBubble(
-                                serviceTitle = service.name,
-                                sellerName = service.seller,
-                                price = "₩%,d".format(service.discountPrice),
-                                thumbnailUrl = service.thumbnail,
-                                direction = if (t.you) ChatBubbleDirection.SENT else ChatBubbleDirection.RECEIVED,
-                                timestamp = t.time.timeToSimpleString(),
-                                imageRequest = imageRequestBuilder,
-                                onDetailClick = {},
-                            )
+                            (message.userId != before.userId) ||
+                                    message.time != before.time
                         }
-                    }
 
-                    is ChatMessage.TextMessage -> {
-                        ChatMessageItem(
-                            text = t.text,
-                            time = t.time,
-                            simple = !full,
-                            userName = message.userId.toString(),
-                            profile = "",
-                            isYou = t.you,
-                            end = t.first,
-                            imageRequestBuilder = imageRequestBuilder,
+                    val insertDayDivider =
+                        if (before == null) false
+                        else (before.time.day != message.time.day ||
+                                before.time.month != message.time.month ||
+                                before.time.year != message.time.year
+                                )
+
+                    if(last||insertDayDivider) {
+                        ChatDivider(
+                            message = message.time.absoluteDateSimpleString(),
                         )
                     }
+                    when (val t = message) {
+                        is ChatMessage.ServiceMessage -> {
+                            val service = uiState.serviceInfo[t.serviceId]
 
-                    else -> {}
-                }
-            }
-        }
-    }
-}
+                            if (service == null) {
+                                ChatServiceShimmerBubble(
+                                    direction = if (t.you) ChatBubbleDirection.SENT else ChatBubbleDirection.RECEIVED,
+                                    timestamp = t.time.timeToSimpleString(),
+                                    isEnd = true,
+                                )
+                            } else {
+                                ChatServiceBubble(
+                                    serviceTitle = service.name,
+                                    sellerName = service.seller,
+                                    price = "₩%,d".format(service.discountPrice),
+                                    thumbnailUrl = service.thumbnail,
+                                    direction = if (t.you) ChatBubbleDirection.SENT else ChatBubbleDirection.RECEIVED,
+                                    timestamp = t.time.timeToSimpleString(),
+                                    imageRequest = imageRequestBuilder,
+                                    onDetailClick = {},
+                                )
+                            }
+                        }
 
-@Composable
-fun SendServicePreviewItem(
-    serviceInfo: ServiceInfo?,
-    imageRequestBuilder: ImageRequest.Builder,
-    modifier: Modifier = Modifier,
-) {
-    val isDataLoading = serviceInfo == null
-    val brush = shimmerBrush(showShimmer = isDataLoading)
-
-    Surface(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .clip(
-                    RoundedCornerShape(
-                        topStart = 16.dp,
-                        topEnd = 16.dp,
-                    ),
-                ),
-        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.9f),
-    ) {
-        Column(
-            modifier =
-                Modifier
-                    .padding(12.dp)
-                    .fillMaxWidth(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Text("다음 상품에 대해 물어보세요!")
-            Spacer(Modifier.height(5.dp))
-            Row(
-                modifier = Modifier,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                // 1. 상품 썸네일 영역
-                if (isDataLoading) {
-                    Box(
-                        modifier =
-                            Modifier
-                                .size(48.dp)
-                                .clip(
-                                    androidx.compose.foundation.shape
-                                        .RoundedCornerShape(8.dp),
-                                ).background(brush),
-                    )
-                } else {
-                    AsyncImage(
-                        model = imageRequestBuilder.data(serviceInfo.thumbnail).build(),
-                        contentDescription = null,
-                        modifier =
-                            Modifier
-                                .size(48.dp)
-                                .clip(
-                                    androidx.compose.foundation.shape
-                                        .RoundedCornerShape(8.dp),
-                                ),
-                        contentScale = ContentScale.Crop,
-                    )
-                }
-
-                Spacer(modifier = Modifier.width(12.dp))
-
-                // 2. 정보 영역 (판매자, 제목, 가격)
-                Column(
-                    modifier = Modifier.weight(1f),
-                ) {
-                    if (isDataLoading) {
-                        // Shimmering Placeholders
-                        Box(
-                            modifier =
-                                Modifier
-                                    .width(60.dp)
-                                    .height(12.dp)
-                                    .background(brush),
-                        )
-                        Spacer(modifier = Modifier.height(4.dp))
-                        Box(
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth(0.7f)
-                                    .height(16.dp)
-                                    .background(brush),
-                        )
-                        Spacer(modifier = Modifier.height(4.dp))
-                        Box(
-                            modifier =
-                                Modifier
-                                    .width(80.dp)
-                                    .height(14.dp)
-                                    .background(brush),
-                        )
-                    } else {
-                        serviceInfo?.let { info ->
-                            Text(
-                                text = info.seller,
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.primary,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                            Text(
-                                text = info.name,
-                                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
-                                color = MaterialTheme.colorScheme.onSurface,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                            Text(
-                                text = "%,d원".format(info.discountPrice),
-                                style = MaterialTheme.typography.labelMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        is ChatMessage.TextMessage -> {
+                            ChatMessageItem(
+                                text = t.text,
+                                time = t.time,
+                                simple = !full,
+                                userName = message.userId.toString(),
+                                profile = "",
+                                isYou = t.you,
+                                end = t.first,
+                                imageRequestBuilder = imageRequestBuilder,
                             )
                         }
+
+                        else -> {}
                     }
                 }
             }
         }
     }
-}
-
-@Composable
-fun ChatMessageItem(
-    text: String,
-    time: DateTime,
-    simple: Boolean,
-    userName: String,
-    profile: String,
-    end: Boolean,
-    isYou: Boolean,
-    imageRequestBuilder: ImageRequest.Builder,
-) {
-    ChatBubble(
-        message = text,
-        userName = userName,
-        profileUrl = profile,
-        timestamp = time.timeToSimpleString(),
-        type = if (simple) ChatBubbleType.SIMPLE else ChatBubbleType.ALL,
-        direction = if (!isYou) ChatBubbleDirection.RECEIVED else ChatBubbleDirection.SENT,
-        isEnd = end,
-        imageRequest = imageRequestBuilder,
-    )
 }

--- a/feature/chat/src/main/kotlin/com/ssavice/chat/ChattingDataUiState.kt
+++ b/feature/chat/src/main/kotlin/com/ssavice/chat/ChattingDataUiState.kt
@@ -1,18 +1,24 @@
 package com.ssavice.chat
 
+import com.ssavice.model.chat.ChattingServiceSummary
+import com.ssavice.model.chat.ChattingUserInfo
 import com.ssavice.model.enums.RoomType
 
-data class ChattingRoomUiState(
-    val userInfo: Map<Long, UserInfo> = emptyMap(),
-    val serviceInfo: Map<Long, ServiceInfo> = emptyMap(),
-    val roomId: String,
-    val roomName: String = "",
-    val roomType: RoomType = RoomType.DM,
-    val roomInfoLoadState: ChattingRoomInfoLoadState = ChattingRoomInfoLoadState.Initial,
-    val chattingRoomState: ChattingRoomState,
+data class ChattingDataUiState(
+    val userInfo: Map<Long, ChattingUserInfo> = emptyMap(),
+    val serviceInfo: Map<Long, ChattingServiceSummary> = emptyMap(),
+)
+
+data class RoomUiState(
+    val yourId: Long,
     val sendingService: Boolean = false,
     val waitingForRedirection: Boolean = false,
     val serviceIdToSend: Long = -1,
+    val roomId: String,
+    val roomName: String = "",
+    val roomType: RoomType = RoomType.DM,
+    val chattingRoomState: ChattingRoomState,
+    val roomInfoLoadState: ChattingRoomInfoLoadState = ChattingRoomInfoLoadState.Initial,
 )
 
 sealed interface ChattingRoomInfoLoadState {
@@ -28,7 +34,11 @@ sealed interface ChattingRoomState {
 
     object Initial : ChattingRoomState
 
+    object Loading : ChattingRoomState
+
     object Ready : ChattingRoomState
+
+    object FETCHING_ID : ChattingRoomState
 }
 
 data class UserInfo(

--- a/feature/chat/src/main/kotlin/com/ssavice/chat/ChattingDataUiState.kt
+++ b/feature/chat/src/main/kotlin/com/ssavice/chat/ChattingDataUiState.kt
@@ -38,7 +38,7 @@ sealed interface ChattingRoomState {
 
     object Ready : ChattingRoomState
 
-    object FETCHING_ID : ChattingRoomState
+    object FetchingId : ChattingRoomState
 }
 
 data class UserInfo(

--- a/feature/chat/src/main/kotlin/com/ssavice/chat/ChattingViewModel.kt
+++ b/feature/chat/src/main/kotlin/com/ssavice/chat/ChattingViewModel.kt
@@ -8,7 +8,6 @@ import androidx.paging.cachedIn
 import androidx.paging.map
 import com.ssavice.chat.navigation.ChatRouteContract
 import com.ssavice.chat.repository.ChatRepository
-import com.ssavice.data.repository.UserInfoRepository
 import com.ssavice.model.DateTime
 import com.ssavice.model.enums.ChatType
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -25,234 +24,238 @@ import javax.inject.Inject
 
 @HiltViewModel
 class ChattingViewModel
-@Inject
-constructor(
-    private val chatRepository: ChatRepository,
-    private val savedStateHandle: SavedStateHandle
-) : ViewModel() {
-    private val opponentId: Long? = savedStateHandle[ChatRouteContract.USER_ID]
-    val chattingUiState by lazy {
-        chatRepository.getChatServiceSummaryMap().combine(
-            chatRepository.getUserInfoMap(),
-        ) { serviceSummary, userInfo ->
-            ChattingDataUiState(
-                userInfo = userInfo,
-                serviceInfo = serviceSummary,
-            )
-        }.stateIn(
-            scope = viewModelScope,
-            started = kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000L),
-            initialValue = ChattingDataUiState(),
-        )
-    }
-    private val _roomUiState by lazy {
-        val roomId: String? = savedStateHandle[ChatRouteContract.ROOM_ID]
-        MutableStateFlow(
-            RoomUiState(
-                chattingRoomState = ChattingRoomState.Initial,
-                roomId = roomId ?: "",
-                serviceIdToSend = savedStateHandle[ChatRouteContract.SERVICE_ID] ?: -1L,
-                sendingService = (savedStateHandle.contains(ChatRouteContract.SERVICE_ID)),
-                yourId = -1L
-            )
-        )
-    }
-
-    val roomUiState = _roomUiState.asStateFlow()
-
-    val pagingState by lazy {
-        chatRepository
-            .getChatMessages(
-                _roomUiState.value.roomId,
-            ).map {
-                var lastTime = DateTime.fromTimeStamp(0)
-                var lastSender = -1L
-                it.map { message ->
-                    val time = DateTime.fromTimeStamp(message.createdAt)
-                    val result =
-                        if (message.type == ChatType.TEXT.value) {
-                            ChatMessage.TextMessage(
-                                userId = message.senderId,
-                                you = message.senderId == roomUiState.value.yourId,
-                                first = lastTime != time || lastSender != message.senderId,
-                                text = message.content,
-                                time = time,
-                                messageId = message.messageId,
-                            )
-                        } else {
-                            message.content.toLongOrNull()?.let { id ->
-                                chatRepository.updateServiceSummaryIfNeed(id)
-                            }
-                            ChatMessage.ServiceMessage(
-                                userId = message.senderId,
-                                you = message.senderId == roomUiState.value.yourId,
-                                serviceId = message.content.toLongOrNull() ?: 0L,
-                                time = time,
-                                messageId = message.messageId,
-                            )
-                        }
-                    lastTime = time
-                    lastSender = message.senderId
-                    result
-                }
-            }.cachedIn(viewModelScope)
-    }
-
-    fun sendChat(message: String) {
-        if (_roomUiState.value.roomId == "" &&
-            opponentId != null &&
-            _roomUiState.value.serviceIdToSend != -1L
-        ) {
-            readyToRedirect(roomUiState.value.yourId, _roomUiState.value.serviceIdToSend)
-            viewModelScope.launch(Dispatchers.IO) {
-                chatRepository.startChat(opponentId, _roomUiState.value.serviceIdToSend, message)
-            }
-        } else if (_roomUiState.value.roomId.isNotEmpty()) {
-            viewModelScope.launch(Dispatchers.IO) {
-                chatRepository.sendChat(
-                    _roomUiState.value.roomId,
-                    message,
-                    _roomUiState.value.roomType
-                )
-            }
-        }
-    }
-
-    private fun readyToRedirect(
-        yourId: Long,
-        serviceId: Long,
-    ) {
-        _roomUiState.update {
-            it.copy(
-                sendingService = false,
-                waitingForRedirection = true,
-            )
-        }
-        viewModelScope.launch(Dispatchers.IO) {
+    @Inject
+    constructor(
+        private val chatRepository: ChatRepository,
+        private val savedStateHandle: SavedStateHandle,
+    ) : ViewModel() {
+        private val opponentId: Long? = savedStateHandle[ChatRouteContract.USER_ID]
+        val chattingUiState by lazy {
             chatRepository
-                .readyForAck(
-                    serviceId = serviceId,
-                    userId = yourId,
-                ).catch { e -> Log.e("ChattingViewModel", "Error while waiting for ack", e) }
-                .collect { roomId ->
-                    roomId.onSuccess { roomId ->
-                        redirectChattingRoom(roomId)
-                    }
-                }
-        }
-    }
-
-    private fun redirectChattingRoom(roomId: String) {
-        _roomUiState.update {
-            it.copy(
-                roomId = roomId,
-                chattingRoomState = ChattingRoomState.Initial,
-            )
-        }
-    }
-
-    fun initRoom() {
-        val roomId: String? = savedStateHandle[ChatRouteContract.ROOM_ID]
-        if(roomId == null) {
-            _roomUiState.update {
-                it.copy(
-                    chattingRoomState = ChattingRoomState.Pending,
-                    roomId = "",
-                    serviceIdToSend = savedStateHandle[ChatRouteContract.SERVICE_ID] ?: -1L,
-                    sendingService = (savedStateHandle.contains(ChatRouteContract.SERVICE_ID))
+                .getChatServiceSummaryMap()
+                .combine(
+                    chatRepository.getUserInfoMap(),
+                ) { serviceSummary, userInfo ->
+                    ChattingDataUiState(
+                        userInfo = userInfo,
+                        serviceInfo = serviceSummary,
+                    )
+                }.stateIn(
+                    scope = viewModelScope,
+                    started =
+                        kotlinx.coroutines.flow.SharingStarted
+                            .WhileSubscribed(5000L),
+                    initialValue = ChattingDataUiState(),
                 )
-            }
-
         }
-        else{
-            _roomUiState.update {
-                it.copy(
-                    roomId = roomId,
+        private val _roomUiState by lazy {
+            val roomId: String? = savedStateHandle[ChatRouteContract.ROOM_ID]
+            MutableStateFlow(
+                RoomUiState(
+                    chattingRoomState = ChattingRoomState.Initial,
+                    roomId = roomId ?: "",
                     serviceIdToSend = savedStateHandle[ChatRouteContract.SERVICE_ID] ?: -1L,
-                    sendingService = (savedStateHandle.contains(ChatRouteContract.SERVICE_ID))
-                )
-            }
-            loadChattingRoomInfo()
-        }
-    }
-
-    fun updateLastRead(messageId: Int) {
-        viewModelScope.launch(Dispatchers.IO) {
-            chatRepository.setLastReadMessageId(_roomUiState.value.roomId, messageId)
-        }
-    }
-
-    fun getYourId() {
-        if (_roomUiState.value.yourId != -1L ||
-            _roomUiState.value.chattingRoomState != ChattingRoomState.Initial
-        ) return
-        _roomUiState.update {
-            it.copy(
-                chattingRoomState = ChattingRoomState.FETCHING_ID
+                    sendingService = (savedStateHandle.contains(ChatRouteContract.SERVICE_ID)),
+                    yourId = -1L,
+                ),
             )
         }
-        viewModelScope.launch(Dispatchers.IO) {
-            var isSuccess = false
-            var retryCount = 0
-            val maxRetries = 5
 
-            while (retryCount < 5 && !isSuccess) {
-                chatRepository.getMyId()
-                    .onSuccess { id ->
-                        _roomUiState.update {
-                            it.copy(yourId = id) // it.yourId가 아닌 받아온 id를 넣어야 함
-                        }
-                        initRoom()
-                        isSuccess = true
+        val roomUiState = _roomUiState.asStateFlow()
+
+        val pagingState by lazy {
+            chatRepository
+                .getChatMessages(
+                    _roomUiState.value.roomId,
+                ).map {
+                    var lastTime = DateTime.fromTimeStamp(0)
+                    var lastSender = -1L
+                    it.map { message ->
+                        val time = DateTime.fromTimeStamp(message.createdAt)
+                        val result =
+                            if (message.type == ChatType.TEXT.value) {
+                                ChatMessage.TextMessage(
+                                    userId = message.senderId,
+                                    you = message.senderId == roomUiState.value.yourId,
+                                    first = lastTime != time || lastSender != message.senderId,
+                                    text = message.content,
+                                    time = time,
+                                    messageId = message.messageId,
+                                )
+                            } else {
+                                message.content.toLongOrNull()?.let { id ->
+                                    chatRepository.updateServiceSummaryIfNeed(id)
+                                }
+                                ChatMessage.ServiceMessage(
+                                    userId = message.senderId,
+                                    you = message.senderId == roomUiState.value.yourId,
+                                    serviceId = message.content.toLongOrNull() ?: 0L,
+                                    time = time,
+                                    messageId = message.messageId,
+                                )
+                            }
+                        lastTime = time
+                        lastSender = message.senderId
+                        result
                     }
-                    .onFailure { error ->
-                        retryCount++
-                        Log.e(TAG, "getMyId 실패 ($retryCount/$maxRetries): ${error.message}")
-
-                        if (retryCount < maxRetries) {
-                            kotlinx.coroutines.delay(1000L * retryCount)
-                        } else {
-                            // 최종 실패 시 처리 (예: 에러 상태 업데이트)
-                            Log.e(TAG, "최대 재시도 횟수 초과")
-                        }
-                    }
-            }
+                }.cachedIn(viewModelScope)
         }
-    }
 
-    fun loadChattingRoomInfo() {
-        if (_roomUiState.value.roomInfoLoadState == ChattingRoomInfoLoadState.Loading) return
-
-        _roomUiState.update {
-            it.copy(
-                roomInfoLoadState = ChattingRoomInfoLoadState.Loading,
-                chattingRoomState = ChattingRoomState.Loading
-            )
-        }
-        viewModelScope.launch(Dispatchers.IO) {
-            chatRepository.getMyId().onSuccess {
-                _roomUiState.update {
-                    it.copy(yourId = it.yourId)
+        fun sendChat(message: String) {
+            if (_roomUiState.value.roomId == "" &&
+                opponentId != null &&
+                _roomUiState.value.serviceIdToSend != -1L
+            ) {
+                readyToRedirect(roomUiState.value.yourId, _roomUiState.value.serviceIdToSend)
+                viewModelScope.launch(Dispatchers.IO) {
+                    chatRepository.startChat(opponentId, _roomUiState.value.serviceIdToSend, message)
                 }
-
-                chatRepository.getRoomInfo(_roomUiState.value.roomId).onSuccess { info ->
-                    _roomUiState.update {
-                        it.copy(
-                            roomName = info.name,
-                            roomType = info.roomType,
-                            roomInfoLoadState = ChattingRoomInfoLoadState.Success,
-                            chattingRoomState = ChattingRoomState.Ready
-                        )
-                    }
-                    chatRepository.updateUserInfoIfNeed(
-                        info.participantIds
+            } else if (_roomUiState.value.roomId.isNotEmpty()) {
+                viewModelScope.launch(Dispatchers.IO) {
+                    chatRepository.sendChat(
+                        _roomUiState.value.roomId,
+                        message,
+                        _roomUiState.value.roomType,
                     )
                 }
             }
         }
-    }
 
-    companion object {
-        const val TAG = "ChattingViewModel"
+        private fun readyToRedirect(
+            yourId: Long,
+            serviceId: Long,
+        ) {
+            _roomUiState.update {
+                it.copy(
+                    sendingService = false,
+                    waitingForRedirection = true,
+                )
+            }
+            viewModelScope.launch(Dispatchers.IO) {
+                chatRepository
+                    .readyForAck(
+                        serviceId = serviceId,
+                        userId = yourId,
+                    ).catch { e -> Log.e("ChattingViewModel", "Error while waiting for ack", e) }
+                    .collect { roomId ->
+                        roomId.onSuccess { roomId ->
+                            redirectChattingRoom(roomId)
+                        }
+                    }
+            }
+        }
+
+        private fun redirectChattingRoom(roomId: String) {
+            _roomUiState.update {
+                it.copy(
+                    roomId = roomId,
+                    chattingRoomState = ChattingRoomState.Initial,
+                )
+            }
+        }
+
+        fun initRoom() {
+            val roomId: String? = savedStateHandle[ChatRouteContract.ROOM_ID]
+            if (roomId == null) {
+                _roomUiState.update {
+                    it.copy(
+                        chattingRoomState = ChattingRoomState.Pending,
+                        roomId = "",
+                        serviceIdToSend = savedStateHandle[ChatRouteContract.SERVICE_ID] ?: -1L,
+                        sendingService = (savedStateHandle.contains(ChatRouteContract.SERVICE_ID)),
+                    )
+                }
+            } else {
+                _roomUiState.update {
+                    it.copy(
+                        roomId = roomId,
+                        serviceIdToSend = savedStateHandle[ChatRouteContract.SERVICE_ID] ?: -1L,
+                        sendingService = (savedStateHandle.contains(ChatRouteContract.SERVICE_ID)),
+                    )
+                }
+                loadChattingRoomInfo()
+            }
+        }
+
+        fun updateLastRead(messageId: Int) {
+            viewModelScope.launch(Dispatchers.IO) {
+                chatRepository.setLastReadMessageId(_roomUiState.value.roomId, messageId)
+            }
+        }
+
+        fun getYourId() {
+            if (_roomUiState.value.yourId != -1L ||
+                _roomUiState.value.chattingRoomState != ChattingRoomState.Initial
+            ) {
+                return
+            }
+            _roomUiState.update {
+                it.copy(
+                    chattingRoomState = ChattingRoomState.FetchingId,
+                )
+            }
+            viewModelScope.launch(Dispatchers.IO) {
+                var isSuccess = false
+                var retryCount = 0
+                val maxRetries = 5
+
+                while (retryCount < 5 && !isSuccess) {
+                    chatRepository
+                        .getMyId()
+                        .onSuccess { id ->
+                            _roomUiState.update {
+                                it.copy(yourId = id) // it.yourId가 아닌 받아온 id를 넣어야 함
+                            }
+                            initRoom()
+                            isSuccess = true
+                        }.onFailure { error ->
+                            retryCount++
+                            Log.e(TAG, "getMyId 실패 ($retryCount/$maxRetries): ${error.message}")
+
+                            if (retryCount < maxRetries) {
+                                kotlinx.coroutines.delay(1000L * retryCount)
+                            } else {
+                                // 최종 실패 시 처리 (예: 에러 상태 업데이트)
+                                Log.e(TAG, "최대 재시도 횟수 초과")
+                            }
+                        }
+                }
+            }
+        }
+
+        fun loadChattingRoomInfo() {
+            if (_roomUiState.value.roomInfoLoadState == ChattingRoomInfoLoadState.Loading) return
+
+            _roomUiState.update {
+                it.copy(
+                    roomInfoLoadState = ChattingRoomInfoLoadState.Loading,
+                    chattingRoomState = ChattingRoomState.Loading,
+                )
+            }
+            viewModelScope.launch(Dispatchers.IO) {
+                chatRepository.getMyId().onSuccess {
+                    _roomUiState.update {
+                        it.copy(yourId = it.yourId)
+                    }
+
+                    chatRepository.getRoomInfo(_roomUiState.value.roomId).onSuccess { info ->
+                        _roomUiState.update {
+                            it.copy(
+                                roomName = info.name,
+                                roomType = info.roomType,
+                                roomInfoLoadState = ChattingRoomInfoLoadState.Success,
+                                chattingRoomState = ChattingRoomState.Ready,
+                            )
+                        }
+                        chatRepository.updateUserInfoIfNeed(
+                            info.participantIds,
+                        )
+                    }
+                }
+            }
+        }
+
+        companion object {
+            const val TAG = "ChattingViewModel"
+        }
     }
-}

--- a/feature/chat/src/main/kotlin/com/ssavice/chat/ChattingViewModel.kt
+++ b/feature/chat/src/main/kotlin/com/ssavice/chat/ChattingViewModel.kt
@@ -8,177 +8,251 @@ import androidx.paging.cachedIn
 import androidx.paging.map
 import com.ssavice.chat.navigation.ChatRouteContract
 import com.ssavice.chat.repository.ChatRepository
+import com.ssavice.data.repository.UserInfoRepository
 import com.ssavice.model.DateTime
 import com.ssavice.model.enums.ChatType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class ChattingViewModel
-    @Inject
-    constructor(
-        private val chatRepository: ChatRepository,
-        private val savedStateHandle: SavedStateHandle,
-    ) : ViewModel() {
-        private val opponentId: Long? = savedStateHandle[ChatRouteContract.USER_ID]
-        private val yourId: Long = 3L
-
-        private val _uiState by lazy {
-            val roomId: String? = savedStateHandle[ChatRouteContract.ROOM_ID]
-            MutableStateFlow(
-                ChattingRoomUiState(
-                    chattingRoomState = if (roomId != null) ChattingRoomState.Ready else ChattingRoomState.Pending,
-                    roomId = roomId ?: "",
-                    serviceIdToSend = savedStateHandle[ChatRouteContract.SERVICE_ID] ?: -1L,
-                    sendingService = (savedStateHandle.contains(ChatRouteContract.SERVICE_ID)),
-                ),
+@Inject
+constructor(
+    private val chatRepository: ChatRepository,
+    private val savedStateHandle: SavedStateHandle
+) : ViewModel() {
+    private val opponentId: Long? = savedStateHandle[ChatRouteContract.USER_ID]
+    val chattingUiState by lazy {
+        chatRepository.getChatServiceSummaryMap().combine(
+            chatRepository.getUserInfoMap(),
+        ) { serviceSummary, userInfo ->
+            ChattingDataUiState(
+                userInfo = userInfo,
+                serviceInfo = serviceSummary,
             )
-        }
-        val uiState = _uiState.asStateFlow()
+        }.stateIn(
+            scope = viewModelScope,
+            started = kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000L),
+            initialValue = ChattingDataUiState(),
+        )
+    }
+    private val _roomUiState by lazy {
+        val roomId: String? = savedStateHandle[ChatRouteContract.ROOM_ID]
+        MutableStateFlow(
+            RoomUiState(
+                chattingRoomState = ChattingRoomState.Initial,
+                roomId = roomId ?: "",
+                serviceIdToSend = savedStateHandle[ChatRouteContract.SERVICE_ID] ?: -1L,
+                sendingService = (savedStateHandle.contains(ChatRouteContract.SERVICE_ID)),
+                yourId = -1L
+            )
+        )
+    }
 
-        val pagingState by lazy {
-            chatRepository
-                .getChatMessages(
-                    _uiState.value.roomId,
-                ).map {
-                    var lastTime = DateTime.fromTimeStamp(0)
-                    var lastSender = -1L
-                    it.map { message ->
-                        val time = DateTime.fromTimeStamp(message.createdAt)
-                        val result =
-                            if (message.type == ChatType.TEXT.value) {
-                                ChatMessage.TextMessage(
-                                    userId = message.senderId,
-                                    you = message.senderId == yourId,
-                                    first = lastTime != time || lastSender != message.senderId,
-                                    text = message.content,
-                                    time = time,
-                                    messageId = message.messageId,
-                                )
-                            } else {
-                                collectServiceInfoIfNotExist(message.content.toLongOrNull() ?: -1L)
-                                ChatMessage.ServiceMessage(
-                                    userId = message.senderId,
-                                    you = message.senderId == yourId,
-                                    serviceId = message.content.toLongOrNull() ?: 0L,
-                                    time = time,
-                                    messageId = message.messageId,
-                                )
+    val roomUiState = _roomUiState.asStateFlow()
+
+    val pagingState by lazy {
+        chatRepository
+            .getChatMessages(
+                _roomUiState.value.roomId,
+            ).map {
+                var lastTime = DateTime.fromTimeStamp(0)
+                var lastSender = -1L
+                it.map { message ->
+                    val time = DateTime.fromTimeStamp(message.createdAt)
+                    val result =
+                        if (message.type == ChatType.TEXT.value) {
+                            ChatMessage.TextMessage(
+                                userId = message.senderId,
+                                you = message.senderId == roomUiState.value.yourId,
+                                first = lastTime != time || lastSender != message.senderId,
+                                text = message.content,
+                                time = time,
+                                messageId = message.messageId,
+                            )
+                        } else {
+                            message.content.toLongOrNull()?.let { id ->
+                                chatRepository.updateServiceSummaryIfNeed(id)
                             }
-                        lastTime = time
-                        lastSender = message.senderId
-                        result
-                    }
-                }.cachedIn(viewModelScope)
-        }
-
-        private fun collectServiceInfoIfNotExist(serviceId: Long) {
-            if (serviceId == -1L) return
-            if (_uiState.value.serviceInfo.containsKey(serviceId)) return
-
-            viewModelScope.launch(Dispatchers.IO) {
-                delay(500)
-                _uiState.update {
-                    val t = it.serviceInfo.toMutableMap()
-                    t[serviceId] =
-                        ServiceInfo(
-                            name = "Info For Test",
-                            thumbnail = "https://picsum.photos/200",
-                            basicPrice = 10000,
-                            discountPrice = 9000,
-                            seller = "Seller",
-                        )
-                    it.copy(
-                        serviceInfo = t,
-                    )
+                            ChatMessage.ServiceMessage(
+                                userId = message.senderId,
+                                you = message.senderId == roomUiState.value.yourId,
+                                serviceId = message.content.toLongOrNull() ?: 0L,
+                                time = time,
+                                messageId = message.messageId,
+                            )
+                        }
+                    lastTime = time
+                    lastSender = message.senderId
+                    result
                 }
-            }
-        }
+            }.cachedIn(viewModelScope)
+    }
 
-        fun requestServiceInfo(serviceId: Long) {
-            collectServiceInfoIfNotExist(serviceId)
-        }
-
-        fun sendChat(message: String) {
-            if (_uiState.value.roomId == "" &&
-                opponentId != null &&
-                uiState.value.serviceIdToSend != -1L
-            ) {
-                readyToRedirect(yourId, uiState.value.serviceIdToSend)
-                viewModelScope.launch(Dispatchers.IO) {
-                    chatRepository.startChat(opponentId, uiState.value.serviceIdToSend, message)
-                }
-            } else if (_uiState.value.roomId.isNotEmpty()) {
-                viewModelScope.launch(Dispatchers.IO) {
-                    chatRepository.sendChat(_uiState.value.roomId, message, _uiState.value.roomType)
-                }
-            }
-        }
-
-        private fun readyToRedirect(
-            yourId: Long,
-            serviceId: Long,
+    fun sendChat(message: String) {
+        if (_roomUiState.value.roomId == "" &&
+            opponentId != null &&
+            _roomUiState.value.serviceIdToSend != -1L
         ) {
-            _uiState.update {
-                it.copy(
-                    sendingService = false,
-                    waitingForRedirection = true,
+            readyToRedirect(roomUiState.value.yourId, _roomUiState.value.serviceIdToSend)
+            viewModelScope.launch(Dispatchers.IO) {
+                chatRepository.startChat(opponentId, _roomUiState.value.serviceIdToSend, message)
+            }
+        } else if (_roomUiState.value.roomId.isNotEmpty()) {
+            viewModelScope.launch(Dispatchers.IO) {
+                chatRepository.sendChat(
+                    _roomUiState.value.roomId,
+                    message,
+                    _roomUiState.value.roomType
                 )
             }
-            viewModelScope.launch(Dispatchers.IO) {
-                chatRepository
-                    .readyForAck(
-                        serviceId = serviceId,
-                        userId = yourId,
-                    ).catch { e -> Log.e("ChattingViewModel", "Error while waiting for ack", e) }
-                    .collect { roomId ->
-                        roomId.onSuccess { roomId ->
-                            redirectChattingRoom(roomId)
+        }
+    }
+
+    private fun readyToRedirect(
+        yourId: Long,
+        serviceId: Long,
+    ) {
+        _roomUiState.update {
+            it.copy(
+                sendingService = false,
+                waitingForRedirection = true,
+            )
+        }
+        viewModelScope.launch(Dispatchers.IO) {
+            chatRepository
+                .readyForAck(
+                    serviceId = serviceId,
+                    userId = yourId,
+                ).catch { e -> Log.e("ChattingViewModel", "Error while waiting for ack", e) }
+                .collect { roomId ->
+                    roomId.onSuccess { roomId ->
+                        redirectChattingRoom(roomId)
+                    }
+                }
+        }
+    }
+
+    private fun redirectChattingRoom(roomId: String) {
+        _roomUiState.update {
+            it.copy(
+                roomId = roomId,
+                chattingRoomState = ChattingRoomState.Initial,
+            )
+        }
+    }
+
+    fun initRoom() {
+        val roomId: String? = savedStateHandle[ChatRouteContract.ROOM_ID]
+        if(roomId == null) {
+            _roomUiState.update {
+                it.copy(
+                    chattingRoomState = ChattingRoomState.Pending,
+                    roomId = "",
+                    serviceIdToSend = savedStateHandle[ChatRouteContract.SERVICE_ID] ?: -1L,
+                    sendingService = (savedStateHandle.contains(ChatRouteContract.SERVICE_ID))
+                )
+            }
+
+        }
+        else{
+            _roomUiState.update {
+                it.copy(
+                    roomId = roomId,
+                    serviceIdToSend = savedStateHandle[ChatRouteContract.SERVICE_ID] ?: -1L,
+                    sendingService = (savedStateHandle.contains(ChatRouteContract.SERVICE_ID))
+                )
+            }
+            loadChattingRoomInfo()
+        }
+    }
+
+    fun updateLastRead(messageId: Int) {
+        viewModelScope.launch(Dispatchers.IO) {
+            chatRepository.setLastReadMessageId(_roomUiState.value.roomId, messageId)
+        }
+    }
+
+    fun getYourId() {
+        if (_roomUiState.value.yourId != -1L ||
+            _roomUiState.value.chattingRoomState != ChattingRoomState.Initial
+        ) return
+        _roomUiState.update {
+            it.copy(
+                chattingRoomState = ChattingRoomState.FETCHING_ID
+            )
+        }
+        viewModelScope.launch(Dispatchers.IO) {
+            var isSuccess = false
+            var retryCount = 0
+            val maxRetries = 5
+
+            while (retryCount < 5 && !isSuccess) {
+                chatRepository.getMyId()
+                    .onSuccess { id ->
+                        _roomUiState.update {
+                            it.copy(yourId = id) // it.yourId가 아닌 받아온 id를 넣어야 함
+                        }
+                        initRoom()
+                        isSuccess = true
+                    }
+                    .onFailure { error ->
+                        retryCount++
+                        Log.e(TAG, "getMyId 실패 ($retryCount/$maxRetries): ${error.message}")
+
+                        if (retryCount < maxRetries) {
+                            kotlinx.coroutines.delay(1000L * retryCount)
+                        } else {
+                            // 최종 실패 시 처리 (예: 에러 상태 업데이트)
+                            Log.e(TAG, "최대 재시도 횟수 초과")
                         }
                     }
             }
         }
+    }
 
-        private fun redirectChattingRoom(roomId: String) {
-            _uiState.update {
-                it.copy(
-                    roomId = roomId,
-                    chattingRoomState = ChattingRoomState.Ready,
-                )
-            }
+    fun loadChattingRoomInfo() {
+        if (_roomUiState.value.roomInfoLoadState == ChattingRoomInfoLoadState.Loading) return
+
+        _roomUiState.update {
+            it.copy(
+                roomInfoLoadState = ChattingRoomInfoLoadState.Loading,
+                chattingRoomState = ChattingRoomState.Loading
+            )
         }
+        viewModelScope.launch(Dispatchers.IO) {
+            chatRepository.getMyId().onSuccess {
+                _roomUiState.update {
+                    it.copy(yourId = it.yourId)
+                }
 
-        fun updateLastRead(messageId: Int) {
-            viewModelScope.launch(Dispatchers.IO) {
-                chatRepository.setLastReadMessageId(_uiState.value.roomId, messageId)
-            }
-        }
-
-        fun loadChattingRoomInfo() {
-            if (_uiState.value.roomInfoLoadState == ChattingRoomInfoLoadState.Loading) return
-
-            _uiState.update {
-                it.copy(roomInfoLoadState = ChattingRoomInfoLoadState.Loading)
-            }
-            viewModelScope.launch(Dispatchers.IO) {
-                chatRepository.getRoomInfo(_uiState.value.roomId).onSuccess { info ->
-                    _uiState.update {
+                chatRepository.getRoomInfo(_roomUiState.value.roomId).onSuccess { info ->
+                    _roomUiState.update {
                         it.copy(
                             roomName = info.name,
                             roomType = info.roomType,
                             roomInfoLoadState = ChattingRoomInfoLoadState.Success,
-                            userInfo = mapOf(), // TODO: 따로 받아와서 처리
+                            chattingRoomState = ChattingRoomState.Ready
                         )
                     }
+                    chatRepository.updateUserInfoIfNeed(
+                        info.participantIds
+                    )
                 }
             }
         }
     }
+
+    companion object {
+        const val TAG = "ChattingViewModel"
+    }
+}

--- a/feature/chat/src/main/kotlin/com/ssavice/chat/ui/ChatDivider.kt
+++ b/feature/chat/src/main/kotlin/com/ssavice/chat/ui/ChatDivider.kt
@@ -1,0 +1,51 @@
+package com.ssavice.chat.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ChatDivider(
+    message: String,
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.outlineVariant, // 기본 색상
+    textColor: Color = MaterialTheme.colorScheme.outline // 텍스트 색상
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 16.dp, horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        // 왼쪽 선
+        HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            thickness = 1.dp,
+            color = color
+        )
+
+        // 중앙 메시지 (날짜 또는 "마지막으로 읽은 메시지")
+        Text(
+            text = message,
+            style = MaterialTheme.typography.labelMedium,
+            color = textColor
+        )
+
+        // 오른쪽 선
+        HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            thickness = 1.dp,
+            color = color
+        )
+    }
+}

--- a/feature/chat/src/main/kotlin/com/ssavice/chat/ui/ChatDivider.kt
+++ b/feature/chat/src/main/kotlin/com/ssavice/chat/ui/ChatDivider.kt
@@ -17,35 +17,36 @@ import androidx.compose.ui.unit.dp
 fun ChatDivider(
     message: String,
     modifier: Modifier = Modifier,
-    color: Color = MaterialTheme.colorScheme.outlineVariant, // 기본 색상
-    textColor: Color = MaterialTheme.colorScheme.outline // 텍스트 색상
+    color: Color = MaterialTheme.colorScheme.outlineVariant,
+    textColor: Color = MaterialTheme.colorScheme.outline,
 ) {
     Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(vertical = 16.dp, horizontal = 16.dp),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp, horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp)
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         // 왼쪽 선
         HorizontalDivider(
             modifier = Modifier.weight(1f),
             thickness = 1.dp,
-            color = color
+            color = color,
         )
 
         // 중앙 메시지 (날짜 또는 "마지막으로 읽은 메시지")
         Text(
             text = message,
             style = MaterialTheme.typography.labelMedium,
-            color = textColor
+            color = textColor,
         )
 
         // 오른쪽 선
         HorizontalDivider(
             modifier = Modifier.weight(1f),
             thickness = 1.dp,
-            color = color
+            color = color,
         )
     }
 }

--- a/feature/chat/src/main/kotlin/com/ssavice/chat/ui/ChatMessageItem.kt
+++ b/feature/chat/src/main/kotlin/com/ssavice/chat/ui/ChatMessageItem.kt
@@ -1,0 +1,31 @@
+package com.ssavice.chat.ui
+
+import androidx.compose.runtime.Composable
+import coil.request.ImageRequest
+import com.ssavice.designsystem.component.ChatBubble
+import com.ssavice.designsystem.component.ChatBubbleDirection
+import com.ssavice.designsystem.component.ChatBubbleType
+import com.ssavice.model.DateTime
+
+@Composable
+fun ChatMessageItem(
+    text: String,
+    time: DateTime,
+    simple: Boolean,
+    userName: String,
+    profile: String,
+    end: Boolean,
+    isYou: Boolean,
+    imageRequestBuilder: ImageRequest.Builder,
+) {
+    ChatBubble(
+        message = text,
+        userName = userName,
+        profileUrl = profile,
+        timestamp = time.timeToSimpleString(),
+        type = if (simple) ChatBubbleType.SIMPLE else ChatBubbleType.ALL,
+        direction = if (!isYou) ChatBubbleDirection.RECEIVED else ChatBubbleDirection.SENT,
+        isEnd = end,
+        imageRequest = imageRequestBuilder,
+    )
+}

--- a/feature/chat/src/main/kotlin/com/ssavice/chat/ui/SendServicePreviewItem.kt
+++ b/feature/chat/src/main/kotlin/com/ssavice/chat/ui/SendServicePreviewItem.kt
@@ -26,10 +26,11 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.ssavice.chat.ServiceInfo
 import com.ssavice.designsystem.theme.shimmerBrush
+import com.ssavice.model.chat.ChattingServiceSummary
 
 @Composable
 fun SendServicePreviewItem(
-    serviceInfo: ServiceInfo?,
+    serviceInfo: ChattingServiceSummary?,
     imageRequestBuilder: ImageRequest.Builder,
     modifier: Modifier = Modifier.Companion,
 ) {
@@ -74,7 +75,7 @@ fun SendServicePreviewItem(
                     )
                 } else {
                     AsyncImage(
-                        model = imageRequestBuilder.data(serviceInfo.thumbnail).build(),
+                        model = imageRequestBuilder.data(serviceInfo.serviceThumbnail).build(),
                         contentDescription = null,
                         modifier =
                             Modifier.Companion
@@ -121,21 +122,21 @@ fun SendServicePreviewItem(
                     } else {
                         serviceInfo?.let { info ->
                             Text(
-                                text = info.seller,
+                                text = info.serviceSeller,
                                 style = MaterialTheme.typography.labelSmall,
                                 color = MaterialTheme.colorScheme.primary,
                                 maxLines = 1,
                                 overflow = TextOverflow.Companion.Ellipsis,
                             )
                             Text(
-                                text = info.name,
+                                text = info.serviceName,
                                 style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Companion.Bold),
                                 color = MaterialTheme.colorScheme.onSurface,
                                 maxLines = 1,
                                 overflow = TextOverflow.Companion.Ellipsis,
                             )
                             Text(
-                                text = "%,d원".format(info.discountPrice),
+                                text = "%,d원".format(info.servicePrice),
                                 style = MaterialTheme.typography.labelMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )

--- a/feature/chat/src/main/kotlin/com/ssavice/chat/ui/SendServicePreviewItem.kt
+++ b/feature/chat/src/main/kotlin/com/ssavice/chat/ui/SendServicePreviewItem.kt
@@ -1,0 +1,148 @@
+package com.ssavice.chat.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.ssavice.chat.ServiceInfo
+import com.ssavice.designsystem.theme.shimmerBrush
+
+@Composable
+fun SendServicePreviewItem(
+    serviceInfo: ServiceInfo?,
+    imageRequestBuilder: ImageRequest.Builder,
+    modifier: Modifier = Modifier.Companion,
+) {
+    val isDataLoading = serviceInfo == null
+    val brush = shimmerBrush(showShimmer = isDataLoading)
+
+    Surface(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clip(
+                    RoundedCornerShape(
+                        topStart = 16.dp,
+                        topEnd = 16.dp,
+                    ),
+                ),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.9f),
+    ) {
+        Column(
+            modifier =
+                Modifier.Companion
+                    .padding(12.dp)
+                    .fillMaxWidth(),
+            horizontalAlignment = Alignment.Companion.CenterHorizontally,
+        ) {
+            Text("다음 상품에 대해 물어보세요!")
+            Spacer(Modifier.Companion.height(5.dp))
+            Row(
+                modifier = Modifier.Companion,
+                verticalAlignment = Alignment.Companion.CenterVertically,
+            ) {
+                // 1. 상품 썸네일 영역
+                if (isDataLoading) {
+                    Box(
+                        modifier =
+                            Modifier.Companion
+                                .size(48.dp)
+                                .clip(
+                                    androidx.compose.foundation.shape
+                                        .RoundedCornerShape(8.dp),
+                                ).background(brush),
+                    )
+                } else {
+                    AsyncImage(
+                        model = imageRequestBuilder.data(serviceInfo.thumbnail).build(),
+                        contentDescription = null,
+                        modifier =
+                            Modifier.Companion
+                                .size(48.dp)
+                                .clip(
+                                    androidx.compose.foundation.shape
+                                        .RoundedCornerShape(8.dp),
+                                ),
+                        contentScale = ContentScale.Companion.Crop,
+                    )
+                }
+
+                Spacer(modifier = Modifier.Companion.width(12.dp))
+
+                // 2. 정보 영역 (판매자, 제목, 가격)
+                Column(
+                    modifier = Modifier.Companion.weight(1f),
+                ) {
+                    if (isDataLoading) {
+                        // Shimmering Placeholders
+                        Box(
+                            modifier =
+                                Modifier.Companion
+                                    .width(60.dp)
+                                    .height(12.dp)
+                                    .background(brush),
+                        )
+                        Spacer(modifier = Modifier.Companion.height(4.dp))
+                        Box(
+                            modifier =
+                                Modifier.Companion
+                                    .fillMaxWidth(0.7f)
+                                    .height(16.dp)
+                                    .background(brush),
+                        )
+                        Spacer(modifier = Modifier.Companion.height(4.dp))
+                        Box(
+                            modifier =
+                                Modifier.Companion
+                                    .width(80.dp)
+                                    .height(14.dp)
+                                    .background(brush),
+                        )
+                    } else {
+                        serviceInfo?.let { info ->
+                            Text(
+                                text = info.seller,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.primary,
+                                maxLines = 1,
+                                overflow = TextOverflow.Companion.Ellipsis,
+                            )
+                            Text(
+                                text = info.name,
+                                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Companion.Bold),
+                                color = MaterialTheme.colorScheme.onSurface,
+                                maxLines = 1,
+                                overflow = TextOverflow.Companion.Ellipsis,
+                            )
+                            Text(
+                                text = "%,d원".format(info.discountPrice),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/feature/login/src/main/java/com/ssavice/login/Login.kt
+++ b/feature/login/src/main/java/com/ssavice/login/Login.kt
@@ -206,14 +206,15 @@ private fun loginWithKakaoTalk(
 private fun loginWithKakaoAccount(
     context: Context,
     onSuccess: (String) -> Unit,
-    onError: (Throwable) -> Unit) {
+    onError: (Throwable) -> Unit,
+) {
     UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
         if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
             return@loginWithKakaoAccount
         } else if (token != null) {
             Log.d(TAG, "로그인 성공 ${token.accessToken}")
             onSuccess(token.accessToken)
-        }else if (error != null) {
+        } else if (error != null) {
             onError(error)
         }
     }
@@ -312,8 +313,7 @@ fun HashKeySpace(modifier: Modifier) {
             Modifier
                 .background(
                     color = MaterialTheme.colorScheme.background,
-                )
-                .clickable {
+                ).clickable {
                     val data = android.content.ClipData.newPlainText("Hash", hashText)
                     CoroutineScope(Dispatchers.Main).launch {
                         clipboardManager.setClipEntry(
@@ -362,12 +362,12 @@ fun LoginPageErrorPreview() {
             loginState =
                 LoginState.Error(
                     "ErrorThisisLongErrorThisisVeryLongError\n" +
-                            "ErrorThisisLongErrorThisisVeryLongErrorErrorThisisLongErrorThisi" +
-                            "sVeryLongErrorErrorThisisLongErrorThisisVeryLongErrorErrorThisisLon" +
-                            "gErrorThisisVeryLongError\nErrorThisisLongErrorThisisVeryLongErrorErr" +
-                            "orThisisLongErrorThisisVeryLongErrorErrorThisisLongErrorThisisVeryLongErr" +
-                            "orErrorThisisLongErrorThisisVeryLongErrorErrorThisisLongErrorThisisVeryL" +
-                            "ongErrorErrorThisisLongErrorThisisVeryLongError",
+                        "ErrorThisisLongErrorThisisVeryLongErrorErrorThisisLongErrorThisi" +
+                        "sVeryLongErrorErrorThisisLongErrorThisisVeryLongErrorErrorThisisLon" +
+                        "gErrorThisisVeryLongError\nErrorThisisLongErrorThisisVeryLongErrorErr" +
+                        "orThisisLongErrorThisisVeryLongErrorErrorThisisLongErrorThisisVeryLongErr" +
+                        "orErrorThisisLongErrorThisisVeryLongErrorErrorThisisLongErrorThisisVeryL" +
+                        "ongErrorErrorThisisLongErrorThisisVeryLongError",
                 ),
             isUser = true,
         )

--- a/feature/login/src/main/java/com/ssavice/login/Login.kt
+++ b/feature/login/src/main/java/com/ssavice/login/Login.kt
@@ -80,7 +80,7 @@ fun LoginRoute(
     LoginPage(
         modifier = modifier,
         onLoginButtonClicked = {
-            loginWithKakaoTalk(
+            loginWithKakaoAccount(
                 context = context,
                 onSuccess = viewModel::onKakaoLoginSuccess,
                 onError = viewModel::onKakaoLoginError,
@@ -107,13 +107,13 @@ fun LoginPage(
             TitleSpace(
                 Modifier
                     .fillMaxWidth()
-                    .weight(2f),
+                    .height(600.dp),
             )
             if (uiState.loginState == LoginState.NeedLogin) {
                 LoginSpace(
                     Modifier
                         .fillMaxWidth()
-                        .weight(1f),
+                        .height(300.dp),
                     onLoginButtonClicked = onLoginButtonClicked,
                     uiState = uiState,
                 )
@@ -188,12 +188,33 @@ private fun loginWithKakaoTalk(
 
             if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
                 return@loginWithKakaoTalk
+            } else if (
+                error is ClientError &&
+                error.reason == ClientErrorCause.NotSupported
+            ) {
+                loginWithKakaoAccount(context, onSuccess, onError)
             } else {
                 onError(error)
             }
         } else if (token != null) {
             Log.d(TAG, "로그인 성공 ${token.accessToken}")
             onSuccess(token.accessToken)
+        }
+    }
+}
+
+private fun loginWithKakaoAccount(
+    context: Context,
+    onSuccess: (String) -> Unit,
+    onError: (Throwable) -> Unit) {
+    UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
+        if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
+            return@loginWithKakaoAccount
+        } else if (token != null) {
+            Log.d(TAG, "로그인 성공 ${token.accessToken}")
+            onSuccess(token.accessToken)
+        }else if (error != null) {
+            onError(error)
         }
     }
 }
@@ -291,7 +312,8 @@ fun HashKeySpace(modifier: Modifier) {
             Modifier
                 .background(
                     color = MaterialTheme.colorScheme.background,
-                ).clickable {
+                )
+                .clickable {
                     val data = android.content.ClipData.newPlainText("Hash", hashText)
                     CoroutineScope(Dispatchers.Main).launch {
                         clipboardManager.setClipEntry(
@@ -340,12 +362,12 @@ fun LoginPageErrorPreview() {
             loginState =
                 LoginState.Error(
                     "ErrorThisisLongErrorThisisVeryLongError\n" +
-                        "ErrorThisisLongErrorThisisVeryLongErrorErrorThisisLongErrorThisi" +
-                        "sVeryLongErrorErrorThisisLongErrorThisisVeryLongErrorErrorThisisLon" +
-                        "gErrorThisisVeryLongError\nErrorThisisLongErrorThisisVeryLongErrorErr" +
-                        "orThisisLongErrorThisisVeryLongErrorErrorThisisLongErrorThisisVeryLongErr" +
-                        "orErrorThisisLongErrorThisisVeryLongErrorErrorThisisLongErrorThisisVeryL" +
-                        "ongErrorErrorThisisLongErrorThisisVeryLongError",
+                            "ErrorThisisLongErrorThisisVeryLongErrorErrorThisisLongErrorThisi" +
+                            "sVeryLongErrorErrorThisisLongErrorThisisVeryLongErrorErrorThisisLon" +
+                            "gErrorThisisVeryLongError\nErrorThisisLongErrorThisisVeryLongErrorErr" +
+                            "orThisisLongErrorThisisVeryLongErrorErrorThisisLongErrorThisisVeryLongErr" +
+                            "orErrorThisisLongErrorThisisVeryLongErrorErrorThisisLongErrorThisisVeryL" +
+                            "ongErrorErrorThisisLongErrorThisisVeryLongError",
                 ),
             isUser = true,
         )

--- a/feature/seller-my-page/src/main/kotlin/com/ssavice/seller_my_page/SellerMyPageRoute.kt
+++ b/feature/seller-my-page/src/main/kotlin/com/ssavice/seller_my_page/SellerMyPageRoute.kt
@@ -15,6 +15,8 @@ import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.outlined.LibraryAddCheck
 import androidx.compose.material.icons.outlined.PersonOff
 import androidx.compose.material.icons.outlined.Reviews
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -23,6 +25,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -66,7 +69,7 @@ fun SellerMyPageRoute(
         onEditProfileButtonClick = onEditProfileButtonClick,
         onParticipatedServiceButtonClick = onParticipatedServiceButtonClick,
         onHelpButtonClick = onHelpButtonClick,
-        onLogoutButtonClick = onLogoutButtonClick,
+        onLogoutButtonClick = viewModel::onLogout,
         onWithdrawButtonClick = onWithdrawButtonClick,
     )
 }
@@ -82,6 +85,7 @@ fun MyPageScreen(
     onLogoutButtonClick: () -> Unit = {},
     onWithdrawButtonClick: () -> Unit = {},
 ) {
+    var showLogoutDialog by remember { mutableStateOf(false) }
     Column(modifier = modifier) {
         ProfileSummary(
             modifier = Modifier.padding(8.dp),
@@ -119,7 +123,7 @@ fun MyPageScreen(
             MyPageSmallItem(
                 icon = Icons.AutoMirrored.Outlined.Logout,
                 title = "로그아웃",
-                onClick = onLogoutButtonClick,
+                onClick = { showLogoutDialog = true },
             )
             MyPageSmallItem(
                 icon = Icons.Outlined.PersonOff,
@@ -129,6 +133,38 @@ fun MyPageScreen(
             )
         }
     }
+
+    if (showLogoutDialog) {
+        LogoutAlertDialog(
+            onApply = {
+                showLogoutDialog = false
+                onLogoutButtonClick()
+            },
+            onDismiss = { showLogoutDialog = false },
+        )
+    }
+}
+
+@Composable
+fun LogoutAlertDialog(
+    onApply: () -> Unit = {},
+    onDismiss: () -> Unit = {},
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = "경고") },
+        text = { Text(text = "로그아웃 하시겠습니까?") },
+        confirmButton = {
+            Button(onClick = onApply) {
+                Text("확인")
+            }
+        },
+        dismissButton = {
+            Button(onClick = onDismiss) {
+                Text("취소")
+            }
+        },
+    )
 }
 
 @Preview

--- a/feature/seller-my-page/src/main/kotlin/com/ssavice/seller_my_page/SellerMyPageViewModel.kt
+++ b/feature/seller-my-page/src/main/kotlin/com/ssavice/seller_my_page/SellerMyPageViewModel.kt
@@ -89,17 +89,17 @@ class SellerMyPageViewModel
             }
         }
 
-    fun onLogout() {
-        viewModelScope.launch(Dispatchers.IO) {
-            authRepository
-                .logout()
-                .onSuccess {
-                    _uiState.value =
-                        _uiState.value.copy(
-                            participationState = MyPageState.Done,
-                        )
-                    userInfoRepository.getUserAddress()
-                }
+        fun onLogout() {
+            viewModelScope.launch(Dispatchers.IO) {
+                authRepository
+                    .logout()
+                    .onSuccess {
+                        _uiState.value =
+                            _uiState.value.copy(
+                                participationState = MyPageState.Done,
+                            )
+                        userInfoRepository.getUserAddress()
+                    }
+            }
         }
-    }
     }

--- a/feature/seller-my-page/src/main/kotlin/com/ssavice/seller_my_page/SellerMyPageViewModel.kt
+++ b/feature/seller-my-page/src/main/kotlin/com/ssavice/seller_my_page/SellerMyPageViewModel.kt
@@ -3,6 +3,8 @@ package com.ssavice.seller_my_page
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ssavice.data.repository.SellerInfoRepository
+import com.ssavice.data.repository.UserInfoRepository
+import com.ssavice.network.authentication.AuthenticationRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,6 +18,8 @@ class SellerMyPageViewModel
     @Inject
     constructor(
         private val sellerInfoRepository: SellerInfoRepository,
+        private val authRepository: AuthenticationRepository,
+        private val userInfoRepository: UserInfoRepository,
     ) : ViewModel() {
         private val _uiState by lazy {
             val mf =
@@ -84,4 +88,18 @@ class SellerMyPageViewModel
                 )
             }
         }
+
+    fun onLogout() {
+        viewModelScope.launch(Dispatchers.IO) {
+            authRepository
+                .logout()
+                .onSuccess {
+                    _uiState.value =
+                        _uiState.value.copy(
+                            participationState = MyPageState.Done,
+                        )
+                    userInfoRepository.getUserAddress()
+                }
+        }
+    }
     }

--- a/ssavice-seller/src/main/AndroidManifest.xml
+++ b/ssavice-seller/src/main/AndroidManifest.xml
@@ -21,6 +21,19 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <!-- 리다이렉트 URI: "kakao${NATIVE_APP_KEY}://oauth" -->
+                <data android:host="oauth"
+                    android:scheme="kakao72db9d913e6a6ac3998a437eec579c67" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/ssavice-seller/src/main/java/com/ssavice_seller/MainActivity.kt
+++ b/ssavice-seller/src/main/java/com/ssavice_seller/MainActivity.kt
@@ -59,6 +59,8 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        KakaoSdk.init(this, BuildConfig.KAKAO_API_KEY_SELLER)
+        KakaoMapSdk.init(this, BuildConfig.KAKAO_API_KEY_SELLER)
         enableEdgeToEdge()
         setContent {
             val navController = rememberNavController()
@@ -105,8 +107,6 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
-        KakaoSdk.init(this, BuildConfig.KAKAO_API_KEY_SELLER)
-        KakaoMapSdk.init(this, BuildConfig.KAKAO_API_KEY_SELLER)
     }
 
     override fun onStart() {


### PR DESCRIPTION
## 🔎 작업 내용
* 채팅 방 내 인원 정보 Remote로 불러온 후 Datasource로 저장하는 기능 구현
* 언급된 서비스 정보 Remote로 불러온 후 Datasource로 저장하는 기능 구현
* 로그인 창에서 카카오톡 미설치 시 카카오 계정으로 로그인 구현


## 체크 리스트
- [ ] 테스트를 작성했습니다.
- [ ] 테스트를 통과했습니다.
- [ ] API 변경사항이 존재합니다.
- [ ] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [ ] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [ ] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- close #
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 